### PR TITLE
Use default API endpoint when no value is provided

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -68,6 +68,7 @@ func configure(ctx context.Context, p *schema.Provider, d *schema.ResourceData) 
 		c        = p.Meta().(*scylla.Client)
 	)
 
+	c.Endpoint = defaultEndpoint
 	if endpoint != "" {
 		var err error
 


### PR DESCRIPTION
It crashes otherwise.