### PR TITLE
internal: close response body after reading it

### DIFF
--- a/internal/scylla/client.go
+++ b/internal/scylla/client.go
@@ -163,6 +163,7 @@ func (c *Client) callAPI(ctx context.Context, method, path string, reqBody, resT
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var buf bytes.Buffer
 


### PR DESCRIPTION
If not closed it affects http connection reuse.