### PR TITLE
internal: don't duplicate http headers

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -55,7 +55,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 		Headers: make(http.Header),
 	}
 
-	c.Headers.Add("Accept", "application/json")
+	c.Headers.Set("Accept", "application/json")
 
 	p.SetMeta(c)
 
@@ -74,7 +74,7 @@ func configure(ctx context.Context, p *schema.Provider, d *schema.ResourceData) 
 		return nil, diag.FromErr(err)
 	}
 
-	c.Headers.Add("User-Agent", userAgent(p.TerraformVersion))
+	c.Headers.Set("User-Agent", userAgent(p.TerraformVersion))
 
 	if err := c.Auth(ctx, token); err != nil {
 		return nil, diag.FromErr(err)

--- a/internal/scylla/client.go
+++ b/internal/scylla/client.go
@@ -68,7 +68,7 @@ func (c *Client) Auth(ctx context.Context, token string) error {
 		c.Headers = make(http.Header)
 	}
 
-	c.Headers.Add("Authorization", "Bearer "+token)
+	c.Headers.Set("Authorization", "Bearer "+token)
 
 	if err := c.findAndSaveAccountID(); err != nil {
 		return err


### PR DESCRIPTION
As configure function is being called more than once on the same client it was adding duplicated headers. This in turn was making some request receive 400 response code from api endpoint.

Fixes https://github.com/scylladb/terraform-provider-scylladbcloud/issues/29