### PR TITLE
provider: add computed values for cluster private IPs and DNS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# binary
+terraform-provider-scylladbcloud
+
+# editor config
+.vscode

--- a/internal/provider/cluster.go
+++ b/internal/provider/cluster.go
@@ -81,6 +81,20 @@ func ResourceCluster() *schema.Resource {
 				ForceNew:    true,
 				Type:        schema.TypeString,
 			},
+			"node_dns_names": {
+				Description: "Cluster nodes DNS names",
+				Computed:    true,
+				Type:        schema.TypeSet,
+				Elem: schema.TypeString,
+				Set: schema.HashString,
+			},
+			"node_private_ips": {
+				Description: "Cluster nodes private IP addresses",
+				Computed:    true,
+				Type:        schema.TypeSet,
+				Elem: schema.TypeString,
+				Set: schema.HashString,
+			},
 			"cidr_block": {
 				Description: "IPv4 CIDR of the cluster",
 				Optional:    true,
@@ -252,6 +266,8 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("node_count", len(model.NodesByStatus(cluster.Nodes, "ACTIVE")))
 	d.Set("user_api_interface", cluster.UserAPIInterface)
 	d.Set("node_type", c.Meta.AWS.InstanceByID(cluster.Datacenter.InstanceID).ExternalID)
+	d.Set("node_dns_names", model.NodesDNSNames(cluster.Nodes))
+	d.Set("node_private_ips", model.NodesPrivateIPs(cluster.Nodes))
 	d.Set("cidr_block", cluster.Datacenter.CIDRBlock)
 	d.Set("scylla_version", cluster.ScyllaVersion.Version)
 	d.Set("enable_vpc_peering", !strings.EqualFold(cluster.BroadcastType, "PUBLIC"))

--- a/internal/scylla/model/model.go
+++ b/internal/scylla/model/model.go
@@ -251,6 +251,22 @@ func NodesByStatus(n []Node, status string) (f []Node) {
 	return f
 }
 
+func NodesPrivateIPs(n []Node) []string {
+	ips := make([]string, 0, len(n))
+	for i := range n {
+		ips = append(ips, n[i].PrivateIP)
+	}
+	return ips
+}
+
+func NodesDNSNames(n []Node) []string {
+	dns := make([]string, 0, len(n))
+	for i := range n {
+		dns = append(dns, n[i].DNS)
+	}
+	return dns
+}
+
 type Datacenters struct {
 	Datacenters []Datacenter `json:"dataCenters"`
 }


### PR DESCRIPTION
Without this there is no easy way to connect to the cluster. I didn't add public IPs as this is not encouraged config. Theoretically private IPs could also be skipped but my yscb setup doesn't want to work with DNS out of the box.