### PR TITLE
feat: add support for context.Context to scylla provider and http client

### DIFF
--- a/internal/provider/cql_auth_data_source.go
+++ b/internal/provider/cql_auth_data_source.go
@@ -65,7 +65,7 @@ func dataSourceCQLAuthRead(ctx context.Context, d *schema.ResourceData, meta int
 		dns        = d.Get("dns").(bool)
 	)
 
-	conn, err := c.Connect(clusterID)
+	conn, err := c.Connect(ctx, clusterID)
 	if err != nil {
 		return diag.Errorf("error reading connection details: %w", err)
 	}
@@ -77,7 +77,7 @@ func dataSourceCQLAuthRead(ctx context.Context, d *schema.ResourceData, meta int
 	var dc *model.DatacenterConnection
 
 	if dcOK {
-		datacenters, err := c.ListDataCenters(clusterID)
+		datacenters, err := c.ListDataCenters(ctx, clusterID)
 		if err != nil {
 			return diag.Errorf("error reading datacenters: %w", err)
 		}

--- a/internal/scylla/client.go
+++ b/internal/scylla/client.go
@@ -84,15 +84,15 @@ func (c *Client) Auth(ctx context.Context, token string) error {
 
 	c.Headers.Set("Authorization", "Bearer "+token)
 
-	if err := c.findAndSaveAccountID(ctx); err != nil {
-		return err
-	}
-
 	if c.Meta == nil {
 		var err error
 		if c.Meta, err = BuildCloudmeta(ctx, c); err != nil {
 			return fmt.Errorf("error building metadata: %w", err)
 		}
+	}
+
+	if err := c.findAndSaveAccountID(ctx); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/scylla/cloudmeta.go
+++ b/internal/scylla/cloudmeta.go
@@ -73,14 +73,14 @@ func BuildCloudmeta(ctx context.Context, c *Client) (*Cloudmeta, error) {
 
 	meta.ErrCodes = m
 
-	versions, err := c.ListScyllaVersions()
+	versions, err := c.ListScyllaVersions(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read scylla versions: %w", err)
 	}
 
 	meta.ScyllaVersions = versions
 
-	providers, err := c.ListCloudProviders()
+	providers, err := c.ListCloudProviders(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read cloud providers: %w", err)
 	}
@@ -88,7 +88,7 @@ func BuildCloudmeta(ctx context.Context, c *Client) (*Cloudmeta, error) {
 	for i := range providers {
 		p := &providers[i]
 
-		regions, err := c.ListCloudProviderRegions(p.ID)
+		regions, err := c.ListCloudProviderRegions(ctx, p.ID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read regions for cloud provider %d: %w", p.ID, err)
 		}

--- a/internal/scylla/endpoints.go
+++ b/internal/scylla/endpoints.go
@@ -1,67 +1,68 @@
 package scylla
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
 	"github.com/scylladb/terraform-provider-scylladbcloud/internal/scylla/model"
 )
 
-func (c *Client) ListCloudProviders() ([]model.CloudProvider, error) {
+func (c *Client) ListCloudProviders(ctx context.Context) ([]model.CloudProvider, error) {
 	var result model.CloudProviders
-	if err := c.get("/deployment/cloud-providers", &result); err != nil {
+	if err := c.get(ctx, "/deployment/cloud-providers", &result); err != nil {
 		return nil, err
 	}
 	return result.CloudProviders, nil
 }
 
-func (c *Client) ListCloudProviderRegions(providerID int64) (*model.CloudProviderRegions, error) {
+func (c *Client) ListCloudProviderRegions(ctx context.Context, providerID int64) (*model.CloudProviderRegions, error) {
 	var result model.CloudProviderRegions
 	path := fmt.Sprintf("/deployment/cloud-provider/%d/regions", providerID)
-	if err := c.get(path, &result, "defaults", "true"); err != nil {
+	if err := c.get(ctx, path, &result, "defaults", "true"); err != nil {
 		return nil, err
 	}
 	return &result, nil
 }
 
-func (c *Client) ListScyllaVersions() (*model.ScyllaVersions, error) {
+func (c *Client) ListScyllaVersions(ctx context.Context) (*model.ScyllaVersions, error) {
 	var result model.ScyllaVersions
 
 	path := "/deployment/scylla-versions"
 
-	if err := c.get(path, &result, "defaults", "true"); err != nil {
+	if err := c.get(ctx, path, &result, "defaults", "true"); err != nil {
 		return nil, err
 	}
 
 	return &result, nil
 }
 
-func (c *Client) ListCloudProviderInstances(providerID int64) ([]model.CloudProviderInstance, error) {
+func (c *Client) ListCloudProviderInstances(ctx context.Context, providerID int64) ([]model.CloudProviderInstance, error) {
 	var result model.CloudProviderRegions
 	path := fmt.Sprintf("/deployment/cloud-provider/%d/regions", providerID)
-	if err := c.get(path, &result, "defaults", "true"); err != nil {
+	if err := c.get(ctx, path, &result, "defaults", "true"); err != nil {
 		return nil, err
 	}
 	return result.Instances, nil
 }
 
-func (c *Client) GetCluster(clusterID int64) (*model.Cluster, error) {
+func (c *Client) GetCluster(ctx context.Context, clusterID int64) (*model.Cluster, error) {
 	var result struct {
 		Cluster model.Cluster `json:"cluster"`
 	}
 
 	path := fmt.Sprintf("/account/%d/cluster/%d", c.AccountID, clusterID)
-	err := c.get(path, &result, "enriched", "true")
+	err := c.get(ctx, path, &result, "enriched", "true")
 
 	return &result.Cluster, err
 }
 
-func (c *Client) Connect(clusterID int64) (*model.ClusterConnection, error) {
+func (c *Client) Connect(ctx context.Context, clusterID int64) (*model.ClusterConnection, error) {
 	var result model.ClusterConnection
 
 	path := fmt.Sprintf("/account/%d/cluster/connect", c.AccountID)
 
-	if err := c.get(path, &result, "clusterId", strconv.FormatInt(clusterID, 10)); err != nil {
+	if err := c.get(ctx, path, &result, "clusterId", strconv.FormatInt(clusterID, 10)); err != nil {
 		return nil, err
 	}
 
@@ -70,14 +71,14 @@ func (c *Client) Connect(clusterID int64) (*model.ClusterConnection, error) {
 	return &result, nil
 }
 
-func (c *Client) CreateCluster(req *model.ClusterCreateRequest) (*model.ClusterRequest, error) {
+func (c *Client) CreateCluster(ctx context.Context, req *model.ClusterCreateRequest) (*model.ClusterRequest, error) {
 	var result struct {
 		RequestID int64 `json:"requestId"`
 	}
 
 	path := fmt.Sprintf("/account/%d/cluster", c.AccountID)
 
-	if err := c.post(path, req, &result); err != nil {
+	if err := c.post(ctx, path, req, &result); err != nil {
 		return nil, err
 	}
 
@@ -85,14 +86,14 @@ func (c *Client) CreateCluster(req *model.ClusterCreateRequest) (*model.ClusterR
 
 	path = fmt.Sprintf("/account/%d/cluster/request/%d", c.AccountID, result.RequestID)
 
-	if err := c.get(path, &clusterReq); err != nil {
+	if err := c.get(ctx, path, &clusterReq); err != nil {
 		return nil, err
 	}
 
 	return &clusterReq, nil
 }
 
-func (c *Client) DeleteCluster(clusterID int64, clusterName string) (*model.ClusterRequest, error) {
+func (c *Client) DeleteCluster(ctx context.Context, clusterID int64, clusterName string) (*model.ClusterRequest, error) {
 	var result model.ClusterRequest
 
 	path := fmt.Sprintf("/account/%d/cluster/%d/delete", c.AccountID, clusterID)
@@ -100,25 +101,25 @@ func (c *Client) DeleteCluster(clusterID int64, clusterName string) (*model.Clus
 		"clusterName": clusterName,
 	}
 
-	if err := c.post(path, data, &result); err != nil {
+	if err := c.post(ctx, path, data, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
 }
 
-func (c *Client) ListClusters() ([]model.Cluster, error) {
+func (c *Client) ListClusters(ctx context.Context) ([]model.Cluster, error) {
 	var result model.Clusters
 
 	path := fmt.Sprintf("/account/%d/clusters", c.AccountID)
 
-	if err := c.get(path, &result, "enriched", "true"); err != nil {
+	if err := c.get(ctx, path, &result, "enriched", "true"); err != nil {
 		return nil, err
 	}
 
 	return result.Clusters, nil
 }
 
-func (c *Client) ListClusterRequest(clusterID int64, typ string) ([]model.ClusterRequest, error) {
+func (c *Client) ListClusterRequest(ctx context.Context, clusterID int64, typ string) ([]model.ClusterRequest, error) {
 	var (
 		result []model.ClusterRequest
 		query  []string
@@ -130,32 +131,32 @@ func (c *Client) ListClusterRequest(clusterID int64, typ string) ([]model.Cluste
 
 	path := fmt.Sprintf("/account/%d/cluster/%d/request", c.AccountID, clusterID)
 
-	if err := c.get(path, &result, query...); err != nil {
+	if err := c.get(ctx, path, &result, query...); err != nil {
 		return nil, err
 	}
 
 	return result, nil
 }
 
-func (c *Client) GetClusterRequest(requestID int64) (model.ClusterRequest, error) {
+func (c *Client) GetClusterRequest(ctx context.Context, requestID int64) (model.ClusterRequest, error) {
 	var result model.ClusterRequest
 	path := fmt.Sprintf("/account/%d/cluster/request/%d", c.AccountID, requestID)
-	err := c.get(path, &result)
+	err := c.get(ctx, path, &result)
 	return result, err
 }
 
-func (c *Client) ListAllowlistRules(clusterID int64) ([]model.AllowedIP, error) {
+func (c *Client) ListAllowlistRules(ctx context.Context, clusterID int64) ([]model.AllowedIP, error) {
 	var result []model.AllowedIP
 
 	path := fmt.Sprintf("/account/%d/cluster/%d/network/firewall/allowed", c.AccountID, clusterID)
 
-	if err := c.get(path, &result); err != nil {
+	if err := c.get(ctx, path, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (c *Client) CreateAllowlistRule(clusterID int64, address string) ([]model.AllowedIP, error) {
+func (c *Client) CreateAllowlistRule(ctx context.Context, clusterID int64, address string) ([]model.AllowedIP, error) {
 	path := fmt.Sprintf("/account/%d/cluster/%d/network/firewall/allowed", c.AccountID, clusterID)
 
 	var result []model.AllowedIP
@@ -164,56 +165,56 @@ func (c *Client) CreateAllowlistRule(clusterID int64, address string) ([]model.A
 		"ipAddress": address,
 	}
 
-	if err := c.post(path, data, &result); err != nil {
+	if err := c.post(ctx, path, data, &result); err != nil {
 		return nil, err
 	}
 
 	return result, nil
 }
 
-func (c *Client) DeleteAllowlistRule(clusterID, ruleID int64) error {
+func (c *Client) DeleteAllowlistRule(ctx context.Context, clusterID, ruleID int64) error {
 	path := fmt.Sprintf("/account/%d/cluster/%d/network/firewall/allowed/%d", c.AccountID, clusterID, ruleID)
 
-	return c.delete(path)
+	return c.delete(ctx, path)
 }
 
-func (c *Client) ListDataCenters(clusterID int64) ([]model.Datacenter, error) {
+func (c *Client) ListDataCenters(ctx context.Context, clusterID int64) ([]model.Datacenter, error) {
 	var result model.Datacenters
 
 	path := fmt.Sprintf("/account/%d/cluster/%d/dcs", c.AccountID, clusterID)
 
-	if err := c.get(path, &result, "enriched", "true"); err != nil {
+	if err := c.get(ctx, path, &result, "enriched", "true"); err != nil {
 		return nil, err
 	}
 
 	return result.Datacenters, nil
 }
 
-func (c *Client) ListClusterNodes(clusterID int64) ([]model.Node, error) {
+func (c *Client) ListClusterNodes(ctx context.Context, clusterID int64) ([]model.Node, error) {
 	var result model.Nodes
 
 	path := fmt.Sprintf("/account/%d/cluster/%d/nodes", c.AccountID, clusterID)
 
-	if err := c.get(path, &result, "enriched", "true"); err != nil {
+	if err := c.get(ctx, path, &result, "enriched", "true"); err != nil {
 		return nil, err
 	}
 
 	return result.Nodes, nil
 }
 
-func (c *Client) ListClusterVPCPeerings(clusterID int64) ([]model.VPCPeering, error) {
+func (c *Client) ListClusterVPCPeerings(ctx context.Context, clusterID int64) ([]model.VPCPeering, error) {
 	var result []model.VPCPeering
 
 	path := fmt.Sprintf("/account/%d/cluster/%d/network/vpc/peer", c.AccountID, clusterID)
 
-	if err := c.get(path, &result); err != nil {
+	if err := c.get(ctx, path, &result); err != nil {
 		return nil, err
 	}
 
 	return result, nil
 }
 
-func (c *Client) CreateClusterVPCPeering(clusterID int64, req *model.VPCPeeringRequest) (*model.VPCPeering, error) {
+func (c *Client) CreateClusterVPCPeering(ctx context.Context, clusterID int64, req *model.VPCPeeringRequest) (*model.VPCPeering, error) {
 	var result struct {
 		ID         int64  `json:"id"`
 		ExternalID string `json:"externalId"`
@@ -221,29 +222,29 @@ func (c *Client) CreateClusterVPCPeering(clusterID int64, req *model.VPCPeeringR
 
 	path := fmt.Sprintf("/account/%d/cluster/%d/network/vpc/peer", c.AccountID, clusterID)
 
-	if err := c.post(path, req, &result); err != nil {
+	if err := c.post(ctx, path, req, &result); err != nil {
 		return nil, err
 	}
 
-	return c.GetClusterVPCPeering(clusterID, result.ID)
+	return c.GetClusterVPCPeering(ctx, clusterID, result.ID)
 }
 
-func (c *Client) GetClusterVPCPeering(clusterID, peerID int64) (*model.VPCPeering, error) {
+func (c *Client) GetClusterVPCPeering(ctx context.Context, clusterID, peerID int64) (*model.VPCPeering, error) {
 	var result model.VPCPeering
 
 	path := fmt.Sprintf("/account/%d/cluster/%d/network/vpc/peer/%d", c.AccountID, clusterID, peerID)
 
-	if err := c.get(path, &result); err != nil {
+	if err := c.get(ctx, path, &result); err != nil {
 		return nil, err
 	}
 
 	return &result, nil
 }
 
-func (c *Client) DeleteClusterVPCPeering(clusterID, peerID int64) error {
+func (c *Client) DeleteClusterVPCPeering(ctx context.Context, clusterID, peerID int64) error {
 	path := fmt.Sprintf("/account/%d/cluster/%d/network/vpc/peer/%d", c.AccountID, clusterID, peerID)
 
-	return c.delete(path)
+	return c.delete(ctx, path)
 }
 
 func fix_sf3112(c *model.ClusterConnection) {


### PR DESCRIPTION
fixes #44 

Also addresses `Cloudmeta` nilness check which in my case was needed before calling `findAndSaveAccountID` in order to fix panic cased by nil `c.Meta.ErrCodes`
```go
if c.Meta == nil {
		var err error
		if c.Meta, err = BuildCloudmeta(ctx, c); err != nil {
			return fmt.Errorf("error building metadata: %w", err)
		}
	}
```

and 
```go
	if data.Error != "" {
		return makeError(data.Error, c.Meta.ErrCodes, resp)
	}
```