### PR TITLE
chore(lint): enable errcheck and discard errors for ResourceData.Set

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,0 @@
-linters:
-  # Disable specific linter
-  # https://golangci-lint.run/usage/linters/#disabled-by-default
-  disable:
-    - errcheck # TODO: disable it after https://github.com/scylladb/terraform-provider-scylladbcloud/issues/71

--- a/internal/provider/allowlist_rule.go
+++ b/internal/provider/allowlist_rule.go
@@ -86,7 +86,7 @@ func resourceAllowlistRuleCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	d.SetId(strconv.Itoa(int(rule.ID)))
-	d.Set("rule_id", rule.ID)
+	_ = d.Set("rule_id", rule.ID)
 
 	return nil
 }
@@ -132,8 +132,8 @@ lookup:
 		return diag.Errorf("unrecognized rule %d", ruleID)
 	}
 
-	d.Set("cidr_block", rule.Address)
-	d.Set("cluster_id", cluster.ID)
+	_ = d.Set("cidr_block", rule.Address)
+	_ = d.Set("cluster_id", cluster.ID)
 
 	return nil
 }

--- a/internal/provider/cluster.go
+++ b/internal/provider/cluster.go
@@ -200,7 +200,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	if !cidrOK {
 		cidr = "172.31.0.0/16"
-		d.Set("cidr_block", cidr)
+		_ = d.Set("cidr_block", cidr)
 	}
 
 	p := c.Meta.ProviderByName(cloud)
@@ -252,7 +252,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	d.SetId(strconv.Itoa(int(cr.ClusterID)))
-	d.Set("request_id", cr.ID)
+	_ = d.Set("request_id", cr.ID)
 
 	return nil
 }
@@ -269,7 +269,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	reqs, err := c.ListClusterRequest(ctx, clusterID, "CREATE_CLUSTER")
 	if scylla.IsDeletedErr(err) {
-		d.Set("status", "DELETED")
+		_ = d.Set("status", "DELETED")
 		return nil
 	} else if err != nil {
 		return diag.Errorf("error reading cluster request: %s", err)
@@ -277,7 +277,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if len(reqs) != 1 {
 		return diag.Errorf("unexpected number of cluster requests, expected 1, got: %+v", reqs)
 	}
-	d.Set("request_id", reqs[0].ID)
+	_ = d.Set("request_id", reqs[0].ID)
 
 	if reqs[0].Status != "COMPLETED" {
 		if err := waitForCluster(ctx, c, reqs[0].ID); err != nil {
@@ -308,25 +308,25 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 }
 
 func setClusterKVs(d *schema.ResourceData, cluster *model.Cluster, p *scylla.CloudProvider) error {
-	d.Set("cluster_id", cluster.ID)
-	d.Set("name", cluster.ClusterName)
-	d.Set("cloud", p.CloudProvider.Name)
-	d.Set("region", cluster.Region.ExternalID)
-	d.Set("node_count", len(model.NodesByStatus(cluster.Nodes, "ACTIVE")))
-	d.Set("user_api_interface", cluster.UserAPIInterface)
-	d.Set("node_type", p.InstanceByID(cluster.Datacenter.InstanceID).ExternalID)
-	d.Set("node_dns_names", model.NodesDNSNames(cluster.Nodes))
-	d.Set("node_private_ips", model.NodesPrivateIPs(cluster.Nodes))
-	d.Set("cidr_block", cluster.Datacenter.CIDRBlock)
-	d.Set("scylla_version", cluster.ScyllaVersion.Version)
-	d.Set("enable_vpc_peering", !strings.EqualFold(cluster.BroadcastType, "PUBLIC"))
-	d.Set("enable_dns", cluster.DNS)
-	d.Set("datacenter_id", cluster.Datacenter.ID)
-	d.Set("datacenter", cluster.Datacenter.Name)
-	d.Set("status", cluster.Status)
+	_ = d.Set("cluster_id", cluster.ID)
+	_ = d.Set("name", cluster.ClusterName)
+	_ = d.Set("cloud", p.CloudProvider.Name)
+	_ = d.Set("region", cluster.Region.ExternalID)
+	_ = d.Set("node_count", len(model.NodesByStatus(cluster.Nodes, "ACTIVE")))
+	_ = d.Set("user_api_interface", cluster.UserAPIInterface)
+	_ = d.Set("node_type", p.InstanceByID(cluster.Datacenter.InstanceID).ExternalID)
+	_ = d.Set("node_dns_names", model.NodesDNSNames(cluster.Nodes))
+	_ = d.Set("node_private_ips", model.NodesPrivateIPs(cluster.Nodes))
+	_ = d.Set("cidr_block", cluster.Datacenter.CIDRBlock)
+	_ = d.Set("scylla_version", cluster.ScyllaVersion.Version)
+	_ = d.Set("enable_vpc_peering", !strings.EqualFold(cluster.BroadcastType, "PUBLIC"))
+	_ = d.Set("enable_dns", cluster.DNS)
+	_ = d.Set("datacenter_id", cluster.Datacenter.ID)
+	_ = d.Set("datacenter", cluster.Datacenter.Name)
+	_ = d.Set("status", cluster.Status)
 
 	if id := cluster.Datacenter.AccountCloudProviderCredentialID; id >= 1000 {
-		d.Set("byoa_id", id)
+		_ = d.Set("byoa_id", id)
 	}
 
 	return nil

--- a/internal/provider/cql_auth_data_source.go
+++ b/internal/provider/cql_auth_data_source.go
@@ -130,9 +130,9 @@ func dataSourceCQLAuthRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	d.SetId(seeds)
-	d.Set("username", conn.Credentials.Username)
-	d.Set("password", conn.Credentials.Password)
-	d.Set("seeds", seeds)
+	_ = d.Set("username", conn.Credentials.Username)
+	_ = d.Set("password", conn.Credentials.Password)
+	_ = d.Set("seeds", seeds)
 
 	return nil
 }

--- a/internal/provider/serverless_bundle_data_source.go
+++ b/internal/provider/serverless_bundle_data_source.go
@@ -61,7 +61,7 @@ func dataSourceServerlessBundleRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	d.SetId(strconv.Itoa(int(clusterID)))
-	d.Set("connection_bundle", string(bundle))
+	_ = d.Set("connection_bundle", string(bundle))
 
 	return nil
 }

--- a/internal/provider/serverless_cluster.go
+++ b/internal/provider/serverless_cluster.go
@@ -99,7 +99,7 @@ func resourceServerlessClusterCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	d.SetId(strconv.Itoa(int(cr.ClusterID)))
-	d.Set("free_tier", cluster.FreeTier)
+	_ = d.Set("free_tier", cluster.FreeTier)
 
 	return nil
 }
@@ -134,7 +134,7 @@ func resourceServerlessClusterRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	d.SetId(strconv.Itoa(int(clusterID)))
-	d.Set("free_tier", cluster.FreeTier)
+	_ = d.Set("free_tier", cluster.FreeTier)
 
 	return nil
 }

--- a/internal/provider/vpc_peering.go
+++ b/internal/provider/vpc_peering.go
@@ -176,9 +176,9 @@ func resourceVPCPeeringCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	d.SetId(vp.ExternalID)
-	d.Set("vpc_peering_id", vp.ID)
-	d.Set("connection_id", vp.ExternalID)
-	d.Set("network_link", vp.NetworkLink())
+	_ = d.Set("vpc_peering_id", vp.ID)
+	_ = d.Set("connection_id", vp.ExternalID)
+	_ = d.Set("network_link", vp.NetworkLink())
 
 	return nil
 }
@@ -231,17 +231,17 @@ lookup:
 
 	r := p.RegionByID(vpcPeering.RegionID)
 
-	d.Set("datacenter", cluster.Datacenter.Name)
-	d.Set("peer_vpc_id", vpcPeering.VPCID)
-	d.Set("peer_region", r.ExternalID)
-	d.Set("peer_account_id", vpcPeering.OwnerID)
-	d.Set("vpc_peering_id", vpcPeering.ID)
-	d.Set("connection_id", vpcPeering.ExternalID)
-	d.Set("cluster_id", cluster.ID)
-	d.Set("network_link", vpcPeering.NetworkLink())
+	_ = d.Set("datacenter", cluster.Datacenter.Name)
+	_ = d.Set("peer_vpc_id", vpcPeering.VPCID)
+	_ = d.Set("peer_region", r.ExternalID)
+	_ = d.Set("peer_account_id", vpcPeering.OwnerID)
+	_ = d.Set("vpc_peering_id", vpcPeering.ID)
+	_ = d.Set("connection_id", vpcPeering.ExternalID)
+	_ = d.Set("cluster_id", cluster.ID)
+	_ = d.Set("network_link", vpcPeering.NetworkLink())
 
 	if c.Meta.GCPBlocks[r.ExternalID] != vpcPeering.CIDRList[0] {
-		d.Set("peer_cidr_block", vpcPeering.CIDRList[0])
+		_ = d.Set("peer_cidr_block", vpcPeering.CIDRList[0])
 	}
 
 	return nil


### PR DESCRIPTION
closes #https://github.com/scylladb/terraform-provider-scylladbcloud/issues/71 
closes #https://github.com/scylladb/terraform-provider-scylladbcloud/issues/65

This PR enables `errcheck` linter back and handles/discards error coming from `ResourceData.Set` and deletes `.golangci.yml` since currently there's no need to configure `golangci-lint` at all, alternatively we could handle the errors with go 1.20 `errors.Join` like so since it only slightly reduces readability

```go
err := errors.Join(
	d.Set("cluster_id", cluster.ID),
	d.Set("name", cluster.ClusterName),
	d.Set("cloud", p.CloudProvider.Name),
	d.Set("region", cluster.Region.ExternalID),
)

if err != nil {
	return err
}
```
