### PR TITLE
feat(peering): add peer_cidr_blocks attribute for VPC peering

### DIFF
--- a/docs/resources/vpc_peering.md
+++ b/docs/resources/vpc_peering.md
@@ -108,7 +108,8 @@ resource "google_compute_network_peering" "app" {
 ### Optional
 
 - `allow_cql` (Boolean) Whether to allow CQL traffic
-- `peer_cidr_block` (String) Peer VPC CIDR block
+- `peer_cidr_block` (String) Peer VPC CIDR block, this attribute also supports comma separated list of CIDR blocks, but this is deprecated and will be removed in the future versions of the provider, for multiple CIDR blocks use peer_cidr_blocks attribute instead
+- `peer_cidr_blocks` (List of String) Peer VPC CIDR block list
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/internal/provider/vpc_peering_test.go
+++ b/internal/provider/vpc_peering_test.go
@@ -1,0 +1,64 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCIDRList(t *testing.T) {
+	type args struct {
+		cidrBlocks any
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "multiple valid cidr blocks",
+			args: args{
+				cidrBlocks: []any{
+					"10.90.5.0/25",
+					"10.76.8.0/25",
+				},
+			},
+			want: []string{
+				"10.90.5.0/25",
+				"10.76.8.0/25",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid type",
+			args: args{
+				cidrBlocks: []any{
+					"10.90.5.0/25",
+					0xdeadbeef,
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "not a slice",
+			args: args{
+				cidrBlocks: "",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CIDRList(tt.args.cidrBlocks)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CIDRList() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CIDRList() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds new attribute to VPC peering called `peer_cidr_blocks` that allows users to specify multiple CIDR blocks using much nicer list syntax instead of comma separated strings and `peer_cidr_block`


### Test run
Manifest
```tf
resource "scylladbcloud_cluster" "cluster" { ... }
resource "scylladbcloud_vpc_peering" "multi-block-peering" {
  ...
  peer_cidr_blocks = ["10.90.5.0/25", "10.76.8.0/25"]
  ...
}

```
---
`tf apply`

```
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

scylladbcloud_cluster_id = "243"
scylladbcloud_vpc_peering_connection_id = "pcx-052110a57ab55aa72"
```
---
`tf destroy`
```
Destroy complete! Resources: 2 destroyed.
```

And internally it creates peering with this list `["10.90.5.0/25","10.76.8.0/25"]`

Still I'm wondering if we need to take any additional measures to handle the optional GCP peering CIDR block https://github.com/scylladb/terraform-provider-scylladbcloud/commit/607646214cef8feb0386b64518b1d7997c61ae5e?

closes https://github.com/scylladb/terraform-provider-scylladbcloud/issues/83
