### PR TITLE
fix(serverless): add processing units and expiration time for serverless

### DIFF
--- a/docs/resources/serverless_cluster.md
+++ b/docs/resources/serverless_cluster.md
@@ -36,8 +36,11 @@ output "scylladbcloud_serverless_cluster_id" {
 ### Read-Only
 
 - `cluster_id` (Number) Serverless cluster id
-- `free_tier` (Boolean) Whether a cluster is in a free tier
+- `free_tier` (Boolean) Whether a cluster is in a free tier. True by default.
 - `id` (String) The ID of this resource.
+- `enable_dns` (Boolean) Whether to enable CNAME for seed nodes. True by default.
+- `units` (Number) Processing units designated for each cluster node
+- `hours` (Number) Number of hours for cluster to last. Applicable only when `free_tier` is True
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/internal/provider/cluster.go
+++ b/internal/provider/cluster.go
@@ -135,8 +135,6 @@ func ResourceCluster() *schema.Resource {
 				Description: "Whether to enable CNAME for seed nodes",
 				Optional:    true,
 				Type:        schema.TypeBool,
-				// NOTE(rjeczalik): ForceNew is commented out here, otherwise
-				// internal provider validate fails due to all the attrs
 				// being ForceNew; Scylla Cloud API does not allow for
 				// updating existing clusters, thus update the implementation
 				// always returns a non-nil error.

--- a/internal/provider/cluster.go
+++ b/internal/provider/cluster.go
@@ -138,8 +138,8 @@ func ResourceCluster() *schema.Resource {
 				// being ForceNew; Scylla Cloud API does not allow for
 				// updating existing clusters, thus update the implementation
 				// always returns a non-nil error.
-				// ForceNew:    true,
-				Default: true,
+				ForceNew: true,
+				Default:  true,
 			},
 			"request_id": {
 				Description: "Cluster creation request ID",

--- a/internal/scylla/client.go
+++ b/internal/scylla/client.go
@@ -116,14 +116,10 @@ func (c *Client) newHttpRequest(ctx context.Context, method, path string, reqBod
 			req.URL.RawQuery = q.Encode()
 		}
 	}
-	headers := bytes.NewBuffer([]byte{})
-	_ = req.Header.Write(headers)
-
-	tflog.Trace(ctx, "Sending api request: "+req.Method+" "+req.URL.String(), map[string]interface{}{
+	tflog.Trace(ctx, "api call prepared: "+req.Method+" "+req.URL.String(), map[string]interface{}{
 		"host":        req.Host,
 		"remote_addr": req.RemoteAddr,
 		"body":        string(body),
-		"headers":     headers,
 	})
 
 	return req, nil

--- a/internal/scylla/client.go
+++ b/internal/scylla/client.go
@@ -116,6 +116,15 @@ func (c *Client) newHttpRequest(ctx context.Context, method, path string, reqBod
 			req.URL.RawQuery = q.Encode()
 		}
 	}
+	headers := bytes.NewBuffer([]byte{})
+	_ = req.Header.Write(headers)
+
+	tflog.Trace(ctx, "Sending api request: "+req.Method+" "+req.URL.String(), map[string]interface{}{
+		"host":        req.Host,
+		"remote_addr": req.RemoteAddr,
+		"body":        string(body),
+		"headers":     headers,
+	})
 
 	return req, nil
 }
@@ -196,6 +205,7 @@ func (c *Client) callAPI(ctx context.Context, method, path string, reqBody, resT
 			"error":  err.Error(),
 			"body":   buf.String(),
 		})
+		err = makeError("failed to unmarshal data: "+err.Error(), c.ErrCodes, resp)
 		return err
 	}
 

--- a/internal/scylla/errors.go
+++ b/internal/scylla/errors.go
@@ -19,6 +19,7 @@ type APIError struct {
 	URL        string
 	Code       string
 	Message    string
+	Method     string
 	StatusCode int
 }
 
@@ -44,9 +45,10 @@ func makeError(text string, errCodes map[string]string, r *http.Response) *APIEr
 	if err.StatusCode == 0 {
 		err.StatusCode = r.StatusCode
 	}
+	err.Method = r.Request.Method
 	return &err
 }
 
 func (err *APIError) Error() string {
-	return fmt.Sprintf("Error %q: %s (http status %d, url %q)", err.Code, err.Message, err.StatusCode, err.URL)
+	return fmt.Sprintf("Error %q: %s (http status %d, method %s url %q)", err.Code, err.Message, err.StatusCode, err.Method, err.URL)
 }

--- a/internal/scylla/model/model.go
+++ b/internal/scylla/model/model.go
@@ -3,6 +3,7 @@ package model
 import (
 	"encoding/json"
 	"strings"
+	"time"
 )
 
 type CloudProvider struct {
@@ -107,6 +108,8 @@ type ClusterCreateRequest struct {
 	ScyllaVersionID          int64    `json:"scyllaVersionId,omitempty"`
 	UserAPIInterface         string   `json:"userApiInterface,omitempty"`
 	Provisioning             string   `json:"provisioning,omitempty"`
+	ProcessingUnits          int      `json:"pu,omitempty" minimum:"1" maximum:"1000" default:"1"`
+	Expiration               string   `json:"expiration,omitempty" example:"12"`
 }
 
 type Cluster struct {
@@ -196,6 +199,16 @@ type Node struct {
 	ServiceID        int64                `json:"serviceID"`
 	ServiceVersionID int64                `json:"serviceVersionID"`
 	Status           string               `json:"status"`
+}
+
+type AccountDeal struct {
+	Type           string
+	ProviderID     int
+	IsEligible     bool
+	ExpirationDate *time.Time `json:",omitempty" yaml:",omitempty"`
+	StartDate      *time.Time `json:",omitempty" yaml:",omitempty"`
+	Total          uint       `json:",omitempty" yaml:",omitempty"`
+	Used           uint       `json:",omitempty" yaml:",omitempty"`
 }
 
 type VPC struct {


### PR DESCRIPTION
There is plan to use terraform script to test serverless bootstraping.
In order to have it we need pu and expiration time exposed