### PR TITLE
fix(api-client): handle error "000001" "Too Many Requests"

### DIFF
--- a/internal/provider/cluster.go
+++ b/internal/provider/cluster.go
@@ -26,7 +26,6 @@ func ResourceCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceClusterCreate,
 		ReadContext:   resourceClusterRead,
-		UpdateContext: resourceClusterUpdate,
 		DeleteContext: resourceClusterDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -35,7 +34,6 @@ func ResourceCluster() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(clusterRetryTimeout),
-			Update: schema.DefaultTimeout(clusterRetryTimeout),
 			Delete: schema.DefaultTimeout(clusterDeleteTimeout),
 		},
 
@@ -328,12 +326,6 @@ func setClusterKVs(d *schema.ResourceData, cluster *model.Cluster, p *scylla.Clo
 	}
 
 	return nil
-}
-
-func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// Scylla Cloud API does not support updating a cluster,
-	// thus the update always fails
-	return diag.Errorf(`updating "scylla_cluster" resource is not supported`)
 }
 
 func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/scylla/errors_test.go
+++ b/internal/scylla/errors_test.go
@@ -1,0 +1,150 @@
+package scylla
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+type fakeSyscallError struct {
+	error
+	temp bool
+}
+
+func (e fakeSyscallError) Error() string { return e.error.Error() }
+
+func (e fakeSyscallError) Temporary() bool {
+	return e.temp
+}
+
+func TestGetRetryInfo(t *testing.T) {
+	t.Parallel()
+
+	url := "https://someurl.com"
+
+	type tcase struct {
+		name     string
+		err      error
+		expected bool
+	}
+
+	var (
+		ECONNABORTED = syscall.ECONNABORTED
+		ECONNRESET   = syscall.ECONNRESET
+	)
+
+	if runtime.GOOS == "windows" {
+		ECONNABORTED = syscall.Errno(10053) // WSAECONNABORTED
+		ECONNRESET = syscall.Errno(10054)   // WSAECONNRESET
+	}
+
+	tcases := []tcase{
+		{
+			name:     "read body error",
+			err:      makeAPIError("error reading body: "+"some reading error", errCodes, url, http.MethodGet, http.StatusOK, 0),
+			expected: false,
+		},
+		{
+			name:     "read body error [bad gateway]",
+			err:      makeAPIError("error reading body: "+"some reading error", errCodes, url, http.MethodGet, http.StatusBadGateway, 0),
+			expected: true,
+		},
+		{
+			name:     "unmarshal error",
+			err:      makeAPIError("failed to unmarshal data: "+"some unmarshal error", errCodes, url, http.MethodGet, http.StatusOK, 0),
+			expected: false,
+		},
+		{
+			name:     "unmarshal error [bad gateway]",
+			err:      makeAPIError("failed to unmarshal data: "+"some unmarshal error", errCodes, url, http.MethodGet, http.StatusBadGateway, 0),
+			expected: true,
+		},
+		{
+			name:     "api error 000001",
+			err:      makeAPIError("000001", errCodes, url, http.MethodGet, http.StatusOK, 0),
+			expected: true,
+		},
+		{
+			name:     "api error 021601",
+			err:      makeAPIError("021601", errCodes, url, http.MethodGet, http.StatusOK, 0),
+			expected: false,
+		},
+		{
+			name: "net op os.SyscallError temp",
+			err: &net.OpError{
+				Op: "accept",
+				Err: &os.SyscallError{
+					Err: fakeSyscallError{
+						error: syscall.ECONNABORTED,
+						temp:  true,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "net op os.SyscallError non-temp",
+			err: &net.OpError{
+				Op: "accept",
+				Err: &os.SyscallError{
+					Err: fakeSyscallError{
+						error: syscall.ECONNABORTED,
+						temp:  false,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "net op temp",
+			err: &net.OpError{
+				Op: "accept",
+				Err: fakeSyscallError{
+					error: syscall.ECONNABORTED,
+					temp:  true,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "net op non-temp",
+			err: &net.OpError{
+				Op: "accept",
+				Err: fakeSyscallError{
+					error: syscall.ECONNABORTED,
+					temp:  false,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "net op accept error ECONNRESET",
+			err: &net.OpError{
+				Op:  "accept",
+				Err: ECONNRESET,
+			},
+			expected: true,
+		},
+		{
+			name: "net op accept error ECONNABORTED",
+			err: &net.OpError{
+				Op:  "accept",
+				Err: ECONNABORTED,
+			},
+			expected: true,
+		}}
+
+	for id := range tcases {
+		tc := tcases[id]
+		t.Run(tc.name, func(t *testing.T) {
+			isTemporary, _ := getRetryInfo(context.Background(), tc.err)
+			if isTemporary != tc.expected {
+				t.Errorf("expected %t, got %t", tc.expected, isTemporary)
+			}
+		})
+	}
+}

--- a/internal/scylla/parse.go
+++ b/internal/scylla/parse.go
@@ -21,6 +21,7 @@ var (
 		}
 		return k, v, nil
 	}
+	errCodes = map[string]string{}
 )
 
 //go:embed blocks.txt


### PR DESCRIPTION
Problem to solve:
1. Retry on error "000001" "Too Many Requests". Last fix (#90) did not work. 
2. Fix tf plugin failure on internal validation: "resource scylladbcloud_cluster: All fields are ForceNew or Computed w/out Optional, Update is superfluous", regression after #88 
