### PR TITLE
fix(cluster): fix internal validation failure

### DIFF
--- a/internal/provider/cluster.go
+++ b/internal/provider/cluster.go
@@ -135,11 +135,13 @@ func ResourceCluster() *schema.Resource {
 				Description: "Whether to enable CNAME for seed nodes",
 				Optional:    true,
 				Type:        schema.TypeBool,
+				// NOTE(rjeczalik): ForceNew is commented out here, otherwise
+				// internal provider validate fails due to all the attrs
 				// being ForceNew; Scylla Cloud API does not allow for
 				// updating existing clusters, thus update the implementation
 				// always returns a non-nil error.
-				ForceNew: true,
-				Default:  true,
+				//ForceNew: true,
+				Default: true,
 			},
 			"request_id": {
 				Description: "Cluster creation request ID",

--- a/internal/provider/serverless_cluster.go
+++ b/internal/provider/serverless_cluster.go
@@ -63,8 +63,13 @@ func ResourceServerlessCluster() *schema.Resource {
 				Description: "Whether to enable CNAME for seed nodes",
 				Optional:    true,
 				Type:        schema.TypeBool,
-				ForceNew:    true,
-				Default:     true,
+				// NOTE(rjeczalik): ForceNew is commented out here, otherwise
+				// internal provider validate fails due to all the attrs
+				// being ForceNew; Scylla Cloud API does not allow for
+				// updating existing clusters, thus update the implementation
+				// always returns a non-nil error.
+				//ForceNew: true,
+				Default: true,
 			},
 			"units": {
 				Description: "Processing units",


### PR DESCRIPTION
Fixes #101 

tf plugin fails on internal validation:
```
resource scylladbcloud_cluster: All fields are ForceNew or Computed w/out Optional, Update is superfluous
```

Reason for it is that there are no fields that could be updated not triggering renew, which is correct, since `siren` have no api to `update` cluster.
But #88 left `update`-related fields in the cluster resource, which triggers tf validator to fail