### PR TITLE
fix: handle AllowCQL and AlternatorWriteIsolation on resource read

### DIFF
--- a/internal/provider/cluster.go
+++ b/internal/provider/cluster.go
@@ -322,6 +322,7 @@ func setClusterKVs(d *schema.ResourceData, cluster *model.Cluster, p *scylla.Clo
 	_ = d.Set("datacenter_id", cluster.Datacenter.ID)
 	_ = d.Set("datacenter", cluster.Datacenter.Name)
 	_ = d.Set("status", cluster.Status)
+	_ = d.Set("alternator_write_isolation", cluster.AlternatorWriteIsolation)
 
 	if id := cluster.Datacenter.AccountCloudProviderCredentialID; id >= 1000 {
 		_ = d.Set("byoa_id", id)

--- a/internal/provider/cluster.go
+++ b/internal/provider/cluster.go
@@ -140,7 +140,7 @@ func ResourceCluster() *schema.Resource {
 				// being ForceNew; Scylla Cloud API does not allow for
 				// updating existing clusters, thus update the implementation
 				// always returns a non-nil error.
-				//ForceNew: true,
+				// ForceNew: true,
 				Default: true,
 			},
 			"request_id": {
@@ -258,9 +258,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		c = meta.(*scylla.Client)
-	)
+	c := meta.(*scylla.Client)
 
 	clusterID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -339,9 +337,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		c = meta.(*scylla.Client)
-	)
+	c := meta.(*scylla.Client)
 
 	clusterID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {

--- a/internal/provider/vpc_peering.go
+++ b/internal/provider/vpc_peering.go
@@ -288,6 +288,7 @@ lookup:
 	_ = d.Set("connection_id", vpcPeering.ExternalID)
 	_ = d.Set("cluster_id", cluster.ID)
 	_ = d.Set("network_link", vpcPeering.NetworkLink())
+	_ = d.Set("allow_cql", vpcPeering.AllowCQL)
 
 	if c.Meta.GCPBlocks[r.ExternalID] != vpcPeering.CIDRList[0] {
 		_ = d.Set("peer_cidr_block", vpcPeering.CIDRList[0])

--- a/internal/scylla/model/model.go
+++ b/internal/scylla/model/model.go
@@ -133,17 +133,18 @@ type Cluster struct {
 	JumpStart           *ExpirationTime        `json:"jumpStart"`
 	Progress            *Progress              `json:"progress"`
 
-	ReplicationFactor int64        `json:"replicationFactor,omitempty"`
-	BroadcastType     string       `json:"broadcastType,omitempty"`
-	GrafanaURL        string       `json:"grafanaUrl,omitempty"`
-	ClientIP          string       `json:"clientIp,omitempty"`
-	CreatedAt         string       `json:"createdAt,omitempty"`
-	PromProxyEnabled  bool         `json:"promProxyEnabled,omitempty"`
-	AllowedIPs        []AllowedIP  `json:"allowedIps,omitempty"`
-	Datacenters       []Datacenter `json:"dataCenters,omitempty"`
-	Nodes             []Node       `json:"nodes,omitempty"`
-	VPCList           []VPC        `json:"vpcList,omitempty"`
-	VPCPeeringList    []VPCPeering `json:"vpcPeeringList,omitempty"`
+	ReplicationFactor        int64        `json:"replicationFactor,omitempty"`
+	BroadcastType            string       `json:"broadcastType,omitempty"`
+	GrafanaURL               string       `json:"grafanaUrl,omitempty"`
+	ClientIP                 string       `json:"clientIp,omitempty"`
+	CreatedAt                string       `json:"createdAt,omitempty"`
+	PromProxyEnabled         bool         `json:"promProxyEnabled,omitempty"`
+	AllowedIPs               []AllowedIP  `json:"allowedIps,omitempty"`
+	Datacenters              []Datacenter `json:"dataCenters,omitempty"`
+	Nodes                    []Node       `json:"nodes,omitempty"`
+	VPCList                  []VPC        `json:"vpcList,omitempty"`
+	VPCPeeringList           []VPCPeering `json:"vpcPeeringList,omitempty"`
+	AlternatorWriteIsolation string       `json:"alternatorWriteIsolation,omitempty"`
 }
 
 type Progress struct {

--- a/internal/scylla/model/model.go
+++ b/internal/scylla/model/model.go
@@ -240,6 +240,7 @@ type VPCPeering struct {
 	ProjectID        string   `json:"projectID"`
 	Status           string   `json:"status"`
 	ExpiresAt        string   `json:"expiresAt"`
+	AllowCQL         string   `json:"allowCQL"`
 }
 
 func (vp *VPCPeering) NetworkLink() string {

--- a/internal/scylla/model/model.go
+++ b/internal/scylla/model/model.go
@@ -241,7 +241,7 @@ type VPCPeering struct {
 	ProjectID        string   `json:"projectID"`
 	Status           string   `json:"status"`
 	ExpiresAt        string   `json:"expiresAt"`
-	AllowCQL         string   `json:"allowCQL"`
+	AllowCQL         string   `json:"allowCql"`
 }
 
 func (vp *VPCPeering) NetworkLink() string {


### PR DESCRIPTION
close https://github.com/scylladb/terraform-provider-scylladbcloud/issues/107

This PR adds support/fixes for:
- `AllowCQL` property for VPC Peering resource
- `AlternatorWriteIsolation` property for cluster resource

These properties were never assigned properly when fetching a resource from Scylla Cloud APIs

context: https://github.com/scylladb/siren-frontend/pull/4102

