### PR TITLE
FIX: Populate only peer_cidr_blocks when there are multiple CIDRS

### DIFF
--- a/internal/provider/vpc_peering.go
+++ b/internal/provider/vpc_peering.go
@@ -290,8 +290,11 @@ lookup:
 	_ = d.Set("network_link", vpcPeering.NetworkLink())
 
 	if c.Meta.GCPBlocks[r.ExternalID] != vpcPeering.CIDRList[0] {
-		_ = d.Set("peer_cidr_block", vpcPeering.CIDRList[0])
-		_ = d.Set("peer_cidr_blocks", vpcPeering.CIDRList)
+		if len(vpcPeering.CIDRList) == 1 {
+			_ = d.Set("peer_cidr_block", vpcPeering.CIDRList[0])
+		}else {
+			_ = d.Set("peer_cidr_blocks", vpcPeering.CIDRList)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Bug: VPC Peering with more than one CIDR block is not working as expected. 

Observed behaviour:
Creation works successfully with multiple CDRS
Terraform plan after creation shows that the VPC Peering will be recreated as the "Terraform refresh" is setting first CIDR in "peer_cidr_block" - Singular

Fix:
Return the plural field "peer_cidr_blocks" when the CIDR array is more than 1 