### PR TITLE
fix(cluster.go): remove datacenter_id assignment

### DIFF
--- a/internal/provider/cluster.go
+++ b/internal/provider/cluster.go
@@ -321,7 +321,6 @@ func setClusterKVs(d *schema.ResourceData, cluster *model.Cluster, p *scylla.Clo
 	_ = d.Set("scylla_version", cluster.ScyllaVersion.Version)
 	_ = d.Set("enable_vpc_peering", !strings.EqualFold(cluster.BroadcastType, "PUBLIC"))
 	_ = d.Set("enable_dns", cluster.DNS)
-	_ = d.Set("datacenter_id", cluster.Datacenter.ID)
 	_ = d.Set("datacenter", cluster.Datacenter.Name)
 	_ = d.Set("status", cluster.Status)
 


### PR DESCRIPTION
Closes #116 

```
> TF_LOG=trace terraform plan
.....
2024-02-09T23:38:57.201-0400 [ERROR] provider.terraform-provider-scylladbcloud_v1.4.2: [ERROR] setting state: Invalid address to set: []string{"datacenter_id"}
.....
```
