### PR TITLE
internal/scylla: introduce proper retry mechanism

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
           gofmt-flags: '-l -d'
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.56.2
       - run: go test -v -race ./...
   test-build:
     strategy:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 toolchain go1.22.0
 
 require (
+	github.com/eapache/go-resiliency v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.22.1
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/eapache/go-resiliency v1.6.0 h1:CqGDTLtpwuWKn6Nj3uNUdflaq+/kIPsg0gfNzHton30=
+github.com/eapache/go-resiliency v1.6.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/internal/scylla/retry.go
+++ b/internal/scylla/retry.go
@@ -1,0 +1,89 @@
+package scylla
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/eapache/go-resiliency/retrier"
+)
+
+var DefaultClassifier retrier.Classifier = &RetryStrategy{
+	RetryStatus: []int{
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+		// http.StatusInternalServerError,
+		http.StatusTooManyRequests,
+		http.StatusRequestTimeout,
+		http.StatusTooEarly,
+		http.StatusLocked,
+	},
+	RetryCode: []string{
+		"000001",
+	},
+	RetryMessage: []string{
+		"connection reset",
+		"use of closed network connection",
+		"broken pipe",
+		"transport connection broken",
+		"connection refused",
+	},
+	FailMessage: []string{
+		"certificate is not trusted",
+		"unsupported protocol scheme",
+		"net/http: request canceled",
+		"net/http: request canceled while waiting for connection",
+	},
+}
+
+type RetryStrategy struct {
+	RetryStatus  []int
+	RetryCode    []string
+	RetryMessage []string
+	FailMessage  []string
+}
+
+func (rs *RetryStrategy) Classify(err error) retrier.Action {
+	if err == nil {
+		return retrier.Succeed
+	}
+
+	if e := (*APIError)(nil); errors.As(err, &e) {
+		if slices.Contains(rs.RetryCode, e.Code) {
+			return retrier.Retry
+		}
+
+		if slices.Contains(rs.RetryStatus, e.StatusCode) {
+			return retrier.Retry
+		}
+	}
+
+	type temp interface {
+		Temporary() bool
+	}
+
+	if e := (temp)(nil); errors.As(err, &e) && e.Temporary() {
+		return retrier.Retry
+	}
+
+	if e := (*net.OpError)(nil); errors.As(err, &e) && e.Op == "dial" {
+		return retrier.Retry
+	}
+
+	for _, msg := range rs.FailMessage {
+		if strings.Contains(err.Error(), msg) {
+			return retrier.Fail
+		}
+	}
+
+	for _, msg := range rs.RetryMessage {
+		if strings.Contains(err.Error(), msg) {
+			return retrier.Retry
+		}
+	}
+
+	return retrier.Fail
+}


### PR DESCRIPTION
Supersedes #100.

This PR introduces configurable retry mechanism, which can be used to implement more complex retry logic.

Currently the retry policy is as follows:

  - we are going to retry on temporary network errors (dial error, broken tcp etc.)
  - we are going to retry on known http statuses (which have limited effect now)
  - we are going to retry on known ScyllaDB Cloud API error codes