### PR TITLE
feat: add the optional node_disk_size attribute

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
           gofmt-flags: '-l -d'
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.56.2
       - run: go test -v -race ./...
   test-build:
     strategy:

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -52,6 +52,7 @@ output "scylladbcloud_cluster_datacenter" {
 - `cloud` (String) Cluster name
 - `enable_dns` (Boolean) Whether to enable CNAME for seed nodes
 - `enable_vpc_peering` (Boolean) Whether to enable VPC peering
+- `node_disk_size` (Number) The disk size in gigabytes of the node
 - `scylla_version` (String) Scylla version
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `user_api_interface` (String) Type of API interface, either CQL or ALTERNATOR

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -425,7 +425,7 @@ func WaitForCluster(ctx context.Context, c *scylla.Client, requestID int64) erro
 	return nil
 }
 
-func resourceClusterUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func resourceClusterUpgradeV0(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
 	var (
 		c                    = meta.(*scylla.Client)
 		cloud, cloudOK       = rawState["cloud"].(string)

--- a/internal/provider/cluster/cluster_v0.go
+++ b/internal/provider/cluster/cluster_v0.go
@@ -1,0 +1,104 @@
+package cluster
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+func resourceClusterV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Computed: true,
+				Type:     schema.TypeInt,
+			},
+			"cloud": {
+				Optional: true,
+				ForceNew: true,
+				Default:  "AWS",
+				Type:     schema.TypeString,
+			},
+			"name": {
+				Required: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"region": {
+				Required: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"node_count": {
+				Required: true,
+				ForceNew: true,
+				Type:     schema.TypeInt,
+			},
+			"byoa_id": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeInt,
+			},
+			"user_api_interface": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+				Default:  "CQL",
+			},
+			"alternator_write_isolation": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+				Default:  "only_rmw_uses_lwt",
+			},
+			"node_type": {
+				Required: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"node_dns_names": {
+				Computed: true,
+				Type:     schema.TypeSet,
+				Elem:     schema.TypeString,
+				Set:      schema.HashString,
+			},
+			"node_private_ips": {
+				Computed: true,
+				Type:     schema.TypeSet,
+				Elem:     schema.TypeString,
+				Set:      schema.HashString,
+			},
+			"cidr_block": {
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"scylla_version": {
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"enable_vpc_peering": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeBool,
+				Default:  true,
+			},
+			"enable_dns": {
+				Optional: true,
+				Type:     schema.TypeBool,
+				Default:  true,
+			},
+			"request_id": {
+				Computed: true,
+				Type:     schema.TypeInt,
+			},
+			"datacenter": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"status": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+		},
+	}
+}

--- a/internal/scylla/cloudmeta.go
+++ b/internal/scylla/cloudmeta.go
@@ -35,26 +35,33 @@ func (p *CloudProvider) RegionByName(name string) *model.CloudProviderRegion {
 	return nil
 }
 
-func (p *CloudProvider) InstanceByID(id int64) *model.CloudProviderInstance {
+func (p *CloudProvider) instanceByFunc(f func(*model.CloudProviderInstance) bool) *model.CloudProviderInstance {
 	for i := range p.CloudProviderRegions.Instances {
 		t := &p.CloudProviderRegions.Instances[i]
 
-		if t.ID == id {
+		if f(t) {
 			return t
 		}
 	}
 	return nil
 }
 
-func (p *CloudProvider) InstanceByName(name string) *model.CloudProviderInstance {
-	for i := range p.CloudProviderRegions.Instances {
-		t := &p.CloudProviderRegions.Instances[i]
+func (p *CloudProvider) InstanceByID(id int64) *model.CloudProviderInstance {
+	return p.instanceByFunc(func(t *model.CloudProviderInstance) bool {
+		return t.ID == id
+	})
+}
 
-		if strings.EqualFold(t.ExternalID, name) {
-			return t
-		}
-	}
-	return nil
+func (p *CloudProvider) InstanceByName(name string) *model.CloudProviderInstance {
+	return p.instanceByFunc(func(t *model.CloudProviderInstance) bool {
+		return strings.EqualFold(t.ExternalID, name)
+	})
+}
+
+func (p *CloudProvider) InstanceByNameAndDiskSize(name string, diskSize int) *model.CloudProviderInstance {
+	return p.instanceByFunc(func(t *model.CloudProviderInstance) bool {
+		return strings.EqualFold(t.ExternalID, name) && t.TotalStorage == int64(diskSize)
+	})
 }
 
 type Cloudmeta struct {


### PR DESCRIPTION
## Motivation and Context
Scylla Cloud has multiple storage size options available for the same `node_type` attributes that currently cannot be selected in the case of the `GCP` provider. For example, `n2-highmem-8` has five distinct storage size options: 375, 750, 1500, 3000, and 6000.

This pull request adds an optional `node_disk_size` attribute that gives the ability to select other storage options.
> [!IMPORTANT]  
> `node_disk_size` must match exactly. If there's no instance with a particular, storage size option, the operation will fail.

Discussion and decisions leading to this implementation can be found in the internal issue with reference number 10003.

## How Has This Been Tested?
### 1. New functionality
As GCP has multiple storage options for the same instance name, I've fetched the list of instances for `us-west-1` region and decided to pick one with 2+ storage options: `n2-highmem-4`:
```
$ curl -s -X GET "https://$API_HOST/deployment/cloud-provider/2/region/32" --header "Authorization: Bearer $API_TOKEN" | jq -r '.data | .instances[] | [.id, .externalId, .totalStorage] | @tsv'
104	e2-micro	60
40	n2-highmem-2	375
47	n2-highmem-2	750
41	n2-highmem-4	750
48	n2-highmem-4	375
49	n2-highmem-4	1500
42	n2-highmem-8	1500
50	n2-highmem-8	375
51	n2-highmem-8	750
52	n2-highmem-8	3000
103	n2-highmem-8	6000
43	n2-highmem-16	3000
53	n2-highmem-16	750
54	n2-highmem-16	1500
55	n2-highmem-16	6000
56	n2-highmem-16	9000
44	n2-highmem-32	9000
57	n2-highmem-32	1500
58	n2-highmem-32	3000
59	n2-highmem-32	6000
46	n2-highmem-48	9000
60	n2-highmem-48	3000
61	n2-highmem-48	6000
94	n2-highmem-64	3000
95	n2-highmem-64	6000
96	n2-highmem-64	9000
97	n2-highmem-80	3000
98	n2-highmem-80	6000
99	n2-highmem-80	9000
```
1. Create infrastructure managed by Terraform, defined as follows:
```hcl
terraform {
  required_providers {
    scylladbcloud = {
      source = "registry.terraform.io/scylladb/scylladbcloud"
    }
  }
}

provider "scylladbcloud" {
  endpoint = "***"
  token    = "***"
}

resource "scylladbcloud_cluster" "test" {
  for_each = toset([
    "375",
    "750"
  ])

  name           = "test-cluster-${each.key}"
  cloud          = "GCP"
  region         = "us-west1"
  node_count     = 3
  node_type      = "n2-highmem-4"
  cidr_block     = "172.31.0.0/16"
  node_disk_size = each.key

  enable_vpc_peering = true
  enable_dns         = true
}
```
2. Check if clusters with the requested attributes were created:
```
$ curl -s -X GET "https://$API_HOST/account/$API_ACCOUNT_ID/clusters?enriched=true" --header "Authorization: Bearer $API_TOKEN" | jq -r '.data.clusters[] | [.clusterName, .instance.id, .instance.externalId,  .instance.totalStorage] | @tsv'
test-cluster-750	41	n2-highmem-4	750
test-cluster-375	48	n2-highmem-4	375
```
3. Fail to create infrastructure with the same definition but with the `node_disk_size = 1234` attribute that doesn't match any particular `n2-highmem-4` instance:
```
$ terraform apply
# ...
╷
│ Error: unrecognized value combination: "n2-highmem-4" for "node_type" and 1234 for "node_disk_size" attributes
│ 
│   with scylladbcloud_cluster.test,
│   on test.tf line 16, in resource "scylladbcloud_cluster" "test":
│   16: resource "scylladbcloud_cluster" "test" {
│ 
╵
```
### 2. Terraform provider upgrade
1. Create infrastructure with the following definition using `v1.5.0` of `terraform-provider-scylladbcloud`:
```hcl
terraform {
  required_providers {
    scylladbcloud = {
      source = "registry.terraform.io/scylladb/scylladbcloud"
    }
  }
}

provider "scylladbcloud" {
  endpoint = "***"
  token    = "***"
}

resource "scylladbcloud_cluster" "test" {
  name       = "test-cluster"
  cloud      = "AWS"
  region     = "us-east-1"
  node_count = 3
  node_type  = "t3.micro"
  cidr_block = "172.31.0.0/16"

  enable_vpc_peering = true
  enable_dns         = true
}
```
2. Override provider with one from this particular pull request branch using `.terraformrc` and `dev_overrides`.
3. Invoke `TF_CLI_CONFIG_FILE=.terraformrc terraform apply` and diff the `terraform.tfstate` file; observe how the `node_disk_size` attribute (which was absent before) is reflecting the actual disk size:
```diff
diff --git a/terraform.tfstate b/terraform.tfstate
index e8cd223..1d301ec 100644
--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.5.7",
-  "serial": 2,
+  "serial": 3,
   "lineage": "c42bf4a9-ecd3-04c8-86e5-0c95742f2a0c",
   "outputs": {
     "scylladbcloud_cluster_datacenter": {
@@ -21,7 +21,7 @@
       "provider": "provider[\"registry.terraform.io/scylladb/scylladbcloud\"]",
       "instances": [
         {
-          "schema_version": 0,
+          "schema_version": 1,
           "attributes": {
             "alternator_write_isolation": "only_rmw_uses_lwt",
             "byoa_id": null,
@@ -34,6 +34,7 @@
             "id": "55",
             "name": "test-cluster",
             "node_count": 3,
+            "node_disk_size": 60,
             "node_dns_names": [
``` 