### PR TITLE
internalprovider: fix inconsistent datacenter references

### DIFF
--- a/docs/data-sources/cql_auth.md
+++ b/docs/data-sources/cql_auth.md
@@ -42,7 +42,7 @@ output "scylladbcloud_cql_password" {
 
 ### Optional
 
-- `datacenter_id` (Number) Datacenter ID
+- `datacenter` (String) Datacenter Name
 - `dns` (Boolean) Use DNS names for seeds
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -348,7 +348,6 @@ func setClusterKVs(d *schema.ResourceData, cluster *model.Cluster, p *scylla.Clo
 	_ = d.Set("scylla_version", cluster.ScyllaVersion.Version)
 	_ = d.Set("enable_vpc_peering", !strings.EqualFold(cluster.BroadcastType, "PUBLIC"))
 	_ = d.Set("enable_dns", cluster.DNS)
-	_ = d.Set("datacenter_id", cluster.Datacenter.ID)
 	_ = d.Set("datacenter", cluster.Datacenter.Name)
 	_ = d.Set("status", cluster.Status)
 

--- a/internal/provider/cqlauth/cql_auth_data_source.go
+++ b/internal/provider/cqlauth/cql_auth_data_source.go
@@ -2,14 +2,15 @@ package cqlauth
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
-	"github.com/scylladb/terraform-provider-scylladbcloud/internal/scylla"
-	"github.com/scylladb/terraform-provider-scylladbcloud/internal/scylla/model"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/scylladb/terraform-provider-scylladbcloud/internal/scylla"
+	"github.com/scylladb/terraform-provider-scylladbcloud/internal/scylla/model"
 )
 
 func DataSourceCQLAuth() *schema.Resource {
@@ -20,15 +21,32 @@ func DataSourceCQLAuth() *schema.Resource {
 			Read: schema.DefaultTimeout(20 * time.Minute),
 		},
 
+		SchemaVersion: 1,
+
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				Type:    dataSourceCQLAuthV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: dataSourceCQLAuthUpgradeFrom0,
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			"cluster_id": {
 				Description: "Cluster ID",
 				Type:        schema.TypeInt,
 				Required:    true,
+				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+					if i.(int) < 1 {
+						return nil, []error{fmt.Errorf("cluster_id must be greater than 0")}
+					}
+					return nil, nil
+				},
 			},
-			"datacenter_id": {
-				Description: "Datacenter ID",
-				Type:        schema.TypeInt,
+			"datacenter": {
+				Description: "Datacenter",
+				Type:        schema.TypeString,
+				Computed:    true,
 				Optional:    true,
 			},
 			"dns": {
@@ -59,10 +77,10 @@ func DataSourceCQLAuth() *schema.Resource {
 
 func dataSourceCQLAuthRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		c          = meta.(*scylla.Client)
-		clusterID  = int64(d.Get("cluster_id").(int))
-		dcID, dcOK = d.GetOk("datacenter_id")
-		dns        = d.Get("dns").(bool)
+		c         = meta.(*scylla.Client)
+		clusterID = int64(d.Get("cluster_id").(int))
+		dcName    = d.Get("datacenter").(string)
+		dns       = d.Get("dns").(bool)
 	)
 
 	conn, err := c.Connect(ctx, clusterID)
@@ -70,69 +88,60 @@ func dataSourceCQLAuthRead(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error reading connection details: %s", err)
 	}
 
-	if len(conn.Datacenters) == 0 {
-		return diag.Errorf("error reading datacenter connections: not found")
+	dc, err := getConnectionDCByName(conn, dcName)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
-	var dc *model.DatacenterConnection
-
-	if dcOK {
-		datacenters, err := c.ListDataCenters(ctx, clusterID)
-		if err != nil {
-			return diag.Errorf("error reading datacenters: %s", err)
-		}
-
-	lookup:
-		for i := range datacenters {
-			lhs := &datacenters[i]
-
-			if lhs.ID == int64(dcID.(int)) {
-				for j := range conn.Datacenters {
-					rhs := &conn.Datacenters[j]
-
-					if strings.EqualFold(lhs.Name, rhs.Name) {
-						dc = rhs
-						break lookup
-					}
-				}
-			}
-		}
-
-		if dc == nil {
-			return diag.Errorf("error looking up datacenter: not found")
-		}
-	} else {
-		dc = &conn.Datacenters[0]
-	}
-
-	var seeds string
-
-	if dns {
-		if len(dc.DNS) == 0 {
-			return diag.Errorf("error reading %q datacenter dns: not found", dc.Name)
-		}
-
-		seeds = strings.Join(dc.DNS, ",")
-	} else {
-		if strings.EqualFold(conn.BroadcastType, "PRIVATE") {
-			if len(dc.PrivateIP) == 0 {
-				return diag.Errorf("error reading %q datacenter private ip: not found", dc.Name)
-			}
-
-			seeds = strings.Join(dc.PrivateIP, ",")
-		} else {
-			if len(dc.PublicIP) == 0 {
-				return diag.Errorf("error reading %q datacenter public ip: not found", dc.Name)
-			}
-
-			seeds = strings.Join(dc.PublicIP, ",")
-		}
+	seeds, err := getSeeds(dns, dc, conn)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.SetId(seeds)
+	_ = d.Set("datacenter", dc.Name)
 	_ = d.Set("username", conn.Credentials.Username)
 	_ = d.Set("password", conn.Credentials.Password)
 	_ = d.Set("seeds", seeds)
 
 	return nil
+}
+
+func getSeeds(dns bool, dc *model.DatacenterConnection, conn *model.ClusterConnection) (string, error) {
+	if dns {
+		if len(dc.DNS) == 0 {
+			return "", fmt.Errorf("error reading %q datacenter dns: not found", dc.Name)
+		}
+
+		return strings.Join(dc.DNS, ","), nil
+	}
+	if strings.EqualFold(conn.BroadcastType, "PRIVATE") {
+		if len(dc.PrivateIP) == 0 {
+			return "", fmt.Errorf("error reading %q datacenter private ip: not found", dc.Name)
+		}
+
+		return strings.Join(dc.PrivateIP, ","), nil
+	}
+	if len(dc.PublicIP) == 0 {
+		return "", fmt.Errorf("error reading %q datacenter public ip: not found", dc.Name)
+	}
+
+	return strings.Join(dc.PublicIP, ","), nil
+}
+
+func getConnectionDCByName(conn *model.ClusterConnection, dcName string) (*model.DatacenterConnection, error) {
+	if len(conn.Datacenters) == 0 {
+		return nil, fmt.Errorf("error reading datacenter connections: not found")
+	}
+
+	if dcName == "" {
+		return &conn.Datacenters[0], nil
+	}
+
+	for _, connDC := range conn.Datacenters {
+		if strings.EqualFold(dcName, connDC.Name) {
+			return &connDC, nil
+		}
+	}
+	return nil, fmt.Errorf("error looking up datacenter: not found")
 }

--- a/internal/provider/cqlauth/cql_auth_data_v0.go
+++ b/internal/provider/cqlauth/cql_auth_data_v0.go
@@ -1,0 +1,105 @@
+package cqlauth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/scylladb/terraform-provider-scylladbcloud/internal/scylla"
+	"github.com/scylladb/terraform-provider-scylladbcloud/internal/scylla/model"
+)
+
+func dataSourceCQLAuthV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"datacenter_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"dns": {
+				Optional: true,
+				Default:  true,
+				Type:     schema.TypeBool,
+			},
+			"seeds": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"username": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"password": {
+				Computed:  true,
+				Sensitive: true,
+				Type:      schema.TypeString,
+			},
+		},
+	}
+}
+
+func dataSourceCQLAuthUpgradeFrom0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	var (
+		c         = meta.(*scylla.Client)
+		clusterID = int64(rawState["cluster_id"].(int))
+		dcID      = rawState["datacenter_id"].(int)
+	)
+
+	conn, err := c.Connect(ctx, clusterID)
+	if err != nil {
+		return nil, fmt.Errorf("error reading connection details: %s", err)
+	}
+
+	datacenters, err := c.ListDataCenters(ctx, clusterID)
+	if err != nil {
+		return nil, fmt.Errorf("error reading datacenters: %s", err)
+	}
+
+	dc, err := getConnectionDCByID(conn, datacenters, int64(dcID))
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]interface{}{
+		"cluster_id": rawState["cluster_id"],
+		"datacenter": dc.Name,
+		"dns":        rawState["dns"],
+		"seeds":      rawState["seeds"],
+		"username":   rawState["username"],
+		"password":   rawState["password"],
+	}, nil
+}
+
+func getConnectionDCByID(conn *model.ClusterConnection, datacenters []model.Datacenter, dcID int64) (*model.DatacenterConnection, error) {
+	if len(conn.Datacenters) == 0 {
+		return nil, fmt.Errorf("error reading datacenter connections: not found")
+	}
+
+	var dc *model.DatacenterConnection
+
+	if dcID == 0 {
+		return &conn.Datacenters[0], nil
+	}
+
+	for i := range datacenters {
+		lhs := &datacenters[i]
+
+		if lhs.ID == dcID {
+			for j := range conn.Datacenters {
+				rhs := &conn.Datacenters[j]
+
+				if strings.EqualFold(lhs.Name, rhs.Name) {
+					return dc, nil
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("error looking up datacenter: not found")
+}


### PR DESCRIPTION
Fixes:
https://github.com/scylladb/terraform-provider-scylladbcloud/issues/116
https://github.com/scylladb/terraform-provider-scylladbcloud/issues/130

Tested:

main.tf:
```
resource "random_string" "postfix" {
  length           = 8
  special          = false
}

resource "scylladbcloud_cluster" "aws" {
  name       = "AWS-statuspage-test2-${random_string.postfix.result}"
  cloud      = "AWS"
  region     = "us-east-1"
  node_count = 3
  node_type  = "t3.micro"
  cidr_block = "172.31.0.0/24"
  enable_dns = true
}

data "scylladbcloud_cql_auth" "example" {
  cluster_id = scylladbcloud_cluster.aws.id
}
```

Steps for `upgrade scenario`:
1. Run `tf init; tf apply`, on current version (`1.5.0`) of terraform provider
2. Upgrade tf provider and run `tf apply`

Steps for `create scenario`:
1. Upgrade tf provider and run `tf apply`

Steps for `create scenario with datacenter`:
1. Change `cql_auth` definition:
```
data "scylladbcloud_cql_auth" "example" {
  cluster_id = scylladbcloud_cluster.aws.id
  datacenter = "AWS_US_EAST_1"
}
``` 
2. Upgrade tf provider and run `tf apply`

