### PR TITLE
fix(cluster): make it treat deleted cluster properly

### DIFF
--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -314,6 +314,10 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	cluster, err := c.GetCluster(ctx, clusterID)
 	if err != nil {
+		if scylla.IsClusterDeletedErr(err) {
+			d.SetId("")
+			return nil // cluster was deleted
+		}
 		return diag.Errorf("error reading cluster: %s", err)
 	}
 

--- a/internal/scylla/errors.go
+++ b/internal/scylla/errors.go
@@ -7,6 +7,13 @@ import (
 	"strconv"
 )
 
+func IsClusterDeletedErr(err error) bool {
+	if e := new(APIError); errors.As(err, &e) && e.Message == "CLUSTER_DELETED" {
+		return true
+	}
+	return false
+}
+
 func IsDeletedErr(err error) bool {
 	if e := new(APIError); errors.As(err, &e) && e.Code == "040001" {
 		return true


### PR DESCRIPTION
Closes #134 

main.tf:
```
resource "scylladbcloud_cluster" "aws" {
  name       = "test-cluster"
  cloud      = "AWS"
  region     = "us-east-1"
  node_count = 3
  node_type  = "t3.micro"
  cidr_block = "172.31.0.0/24"
  enable_dns = true
}
```

Steps to reproduce:
1. `terraform apply`
2. Delete cluster on UI
3. `terraform destroy`

Currently endup in error:
```
│ Error: error reading cluster: Error "": CLUSTER_DELETED (http status 200, method GET url "https://app-api-dkropachev.ext.lab.scylla.cloud/account/100165/cluster/292?enriched=true")
│ 
│   with scylladbcloud_cluster.aws,
│   on main.tf line 6, in resource "scylladbcloud_cluster" "aws":
│    6: resource "scylladbcloud_cluster" "aws" {
│ 
╵
```