### PR TITLE
fix(vpc-peering): delete state when object is deleted from the scylla cloud

### DIFF
--- a/internal/provider/vpcpeering/vpc_peering.go
+++ b/internal/provider/vpcpeering/vpc_peering.go
@@ -271,11 +271,13 @@ lookup:
 
 	if cluster == nil {
 		// cluster was deleted manually
+		d.SetId("")
 		return nil
 	}
 
 	if vpcPeering == nil {
 		// vpc peering was deleted manually
+		d.SetId("")
 		return nil
 	}
 


### PR DESCRIPTION
Closes #137

Covers two scenarios:
First scenario
1. Cluster and VPC Peering is created by terraform
2. VPC Peering is deleted, on the scylla cloud via something else but terraform.
3. `terraform apply`, that should recreate it

Second scenario
1. Cluster and VPC Peering is created by terraform
2. Cluster is deleted, on the scylla cloud via something else but terraform.
3. `terraform apply`, that should recreate it

