### PR TITLE
internal/provider/connection: fix lint warnings

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
           gofmt-flags: '-l -d'
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56.2
+          version: v1.62.2
       - run: go test -v -race ./...
   test-build:
     strategy:

--- a/internal/provider/connection/connection.go
+++ b/internal/provider/connection/connection.go
@@ -190,7 +190,7 @@ func resourceClusterConnectionCreate(ctx context.Context, d *schema.ResourceData
 	d.SetId(strconv.FormatInt(conn.ID, 10))
 	err = waitForClusterConnection(ctx, c, int64(clusterID), conn.ID, "ACTIVE")
 	if err != nil {
-		return diag.Errorf(err.Error())
+		return diag.Errorf("%+v", err)
 	}
 	conn, err = c.GetClusterConnection(ctx, int64(clusterID), conn.ID)
 	if err != nil {
@@ -283,7 +283,7 @@ func resourceClusterConnectionUpdate(ctx context.Context, d *schema.ResourceData
 	}
 	err = waitForClusterConnection(ctx, c, int64(clusterID), connID, req.Status)
 	if err != nil {
-		return diag.Errorf(err.Error())
+		return diag.Errorf("%+v", err)
 	}
 
 	conn, err := c.GetClusterConnection(ctx, int64(clusterID), connID)


### PR DESCRIPTION
Fixes https://github.com/scylladb/terraform-provider-scylladbcloud/issues/179.