### PR TITLE
remove userFriendlyError, filed was empty and is deprecated

### DIFF
--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -411,7 +411,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if !strings.EqualFold(r.Status, "QUEUED") && !strings.EqualFold(r.Status, "IN_PROGRESS") && !strings.EqualFold(r.Status, "COMPLETED") {
-		return diag.Errorf("delete request failure: %q", r.UserFriendlyError)
+		return diag.Errorf("delete request failure, cluster request id: %q", r.ID)
 	}
 
 	return nil
@@ -432,7 +432,7 @@ func WaitForCluster(ctx context.Context, c *scylla.Client, requestID int64) erro
 		} else if strings.EqualFold(r.Status, "QUEUED") || strings.EqualFold(r.Status, "IN_PROGRESS") {
 			continue
 		} else if strings.EqualFold(r.Status, "FAILED") {
-			return fmt.Errorf("cluster request failed: %q", r.UserFriendlyError)
+			return fmt.Errorf("cluster request failed, cluster request id: %q", r.ID)
 		}
 
 		return fmt.Errorf("unrecognized cluster request status: %q", r.Status)

--- a/internal/provider/serverless/serverless_cluster.go
+++ b/internal/provider/serverless/serverless_cluster.go
@@ -209,7 +209,7 @@ func resourceServerlessClusterDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	if !strings.EqualFold(r.Status, "QUEUED") && !strings.EqualFold(r.Status, "IN_PROGRESS") && !strings.EqualFold(r.Status, "COMPLETED") {
-		return diag.Errorf("delete request failure: %q", r.UserFriendlyError)
+		return diag.Errorf("delete request failure, cluster request id: %q", r.ID)
 	}
 
 	return nil

--- a/internal/scylla/model/model.go
+++ b/internal/scylla/model/model.go
@@ -85,7 +85,6 @@ type ClusterRequest struct {
 	ProgressPercent     int64  `json:"progressPercent"`
 	ProgressDescription string `json:"progressDescription"`
 	ClusterID           int64  `json:"clusterID"`
-	UserFriendlyError   string `json:"userFriendlyError"`
 	Status              string `json:"status"`
 }
 


### PR DESCRIPTION
[#12512](https://github.com/scylladb/siren/issues/12512)
userFriendlyError was not used for 2 years, 
and if the terraform action failed, there would be an empty error

I propose to add ClusterRequest.ID so the user will have something to hang on to