### PR TITLE
feat(cql_auth): add cluster name to data source

### DIFF
--- a/docs/data-sources/cql_auth.md
+++ b/docs/data-sources/cql_auth.md
@@ -49,6 +49,7 @@ output "scylladbcloud_cql_password" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `cluster_name` (String) The name of the cluster
 - `password` (String, Sensitive) CQL password
 - `seeds` (String) Comma-separate seed node addresses
 - `username` (String) CQL username

--- a/examples/data-sources/scylladbcloud_cql_auth/data-source.tf
+++ b/examples/data-sources/scylladbcloud_cql_auth/data-source.tf
@@ -16,3 +16,7 @@ output "scylladbcloud_cql_password" {
     sensitive = true
 	value = data.scylladbcloud_cql_auth.example.password
 }
+
+output "scylladbcloud_cql_cluster_name" {
+  value = data.scylladbcloud_cql_auth.example.cluster_name
+}

--- a/internal/provider/cqlauth/cql_auth_data_source.go
+++ b/internal/provider/cqlauth/cql_auth_data_source.go
@@ -49,6 +49,11 @@ func DataSourceCQLAuth() *schema.Resource {
 				Computed:    true,
 				Optional:    true,
 			},
+			"cluster_name": {
+				Description: "Cluster name",
+				Computed:    true,
+				Type:        schema.TypeString,
+			},
 			"dns": {
 				Description: "Use DNS names for seeds",
 				Optional:    true,
@@ -83,6 +88,11 @@ func dataSourceCQLAuthRead(ctx context.Context, d *schema.ResourceData, meta int
 		dns       = d.Get("dns").(bool)
 	)
 
+	cluster, err := c.GetCluster(ctx, clusterID)
+	if err != nil {
+		return diag.Errorf("error reading cluster: %s", err)
+	}
+
 	conn, err := c.Connect(ctx, clusterID)
 	if err != nil {
 		return diag.Errorf("error reading connection details: %s", err)
@@ -99,6 +109,7 @@ func dataSourceCQLAuthRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	d.SetId(seeds)
+	_ = d.Set("cluster_name", cluster.ClusterName)
 	_ = d.Set("datacenter", dc.Name)
 	_ = d.Set("username", conn.Credentials.Username)
 	_ = d.Set("password", conn.Credentials.Password)


### PR DESCRIPTION
The `scylladbcloud_cql_auth` data source now exposes the `cluster_name` of the cluster as a read-only attribute.

This allows users to get the cluster name along with the CQL authentication details in a single data source.