### PR TITLE
feat(cluster): add support for availability zones

### DIFF
--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -338,6 +338,16 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("failed to read cluster %d: %s", cr.ClusterID, err)
 	}
 
+	// Only GetDataCenter returns the Topology field which contains AZ IDs.
+	// We set it to the existing cluster variable which is then used to
+	// set the KVs.
+	datacenter, err := scyllaClient.GetDataCenter(ctx, cr.ClusterID, cluster.Datacenter.ID)
+	if err != nil {
+		return diag.Errorf("failed to read datacenter %d: %s", cluster.Datacenter.ID, err)
+	}
+	cluster.Datacenter.Topology = datacenter.Topology
+	cluster.Datacenters[0].Topology = datacenter.Topology
+
 	i := cloudProvider.InstanceByIDFromInstances(cluster.Datacenter.InstanceID, instances)
 	if i == nil {
 		return diag.Errorf("unexpected instance ID for cluster %d: %d", cluster.ID, cluster.Datacenter.InstanceID)

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -344,16 +344,6 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("clusters without datacenter or multi-datacenter clusters are not currently supported (found %d datacenters)", n)
 	}
 
-	// Only GetDataCenter returns the Topology field which contains AZ IDs.
-	// We set it to the existing cluster variable which is then used to
-	// set the KVs.
-	datacenter, err := scyllaClient.GetDataCenter(ctx, cr.ClusterID, cluster.Datacenter.ID)
-	if err != nil {
-		return diag.Errorf("failed to read datacenter %d: %s", cluster.Datacenter.ID, err)
-	}
-	cluster.Datacenter.Topology = datacenter.Topology
-	cluster.Datacenters[0].Topology = datacenter.Topology
-
 	i := cloudProvider.InstanceByIDFromInstances(cluster.Datacenter.InstanceID, instances)
 	if i == nil {
 		return diag.Errorf("unexpected instance ID for cluster %d: %d", cluster.ID, cluster.Datacenter.InstanceID)
@@ -417,16 +407,6 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if n := len(cluster.Datacenters); n != 1 {
 		return diag.Errorf("clusters without datacenter or multi-datacenter clusters are not currently supported (found %d datacenters)", n)
 	}
-
-	// Only GetDataCenter returns the Topology field which contains AZ IDs.
-	// We set it to the existing cluster variable which is then used to
-	// set the KVs.
-	datacenter, err := scyllaClient.GetDataCenter(ctx, clusterID, cluster.Datacenter.ID)
-	if err != nil {
-		return diag.Errorf("failed to read datacenter %d: %s", cluster.Datacenter.ID, err)
-	}
-	cluster.Datacenter.Topology = datacenter.Topology
-	cluster.Datacenters[0].Topology = datacenter.Topology
 
 	var instanceExternalID string
 	if cluster.Datacenter.InstanceID != 0 {

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -303,8 +303,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			}
 		}
 
+		azIDsSet := azIDs.(*schema.Set)
+
 		var azIDList []string
-		for _, v := range azIDs.([]interface{}) {
+		for _, v := range azIDsSet.List() {
 			azIDList = append(azIDList, v.(string))
 		}
 		slices.Sort(azIDList)

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -39,7 +40,7 @@ func ResourceCluster() *schema.Resource {
 			Delete: schema.DefaultTimeout(clusterDeleteTimeout),
 		},
 
-		SchemaVersion: 2,
+		SchemaVersion: 3,
 
 		StateUpgraders: []schema.StateUpgrader{
 			{
@@ -51,6 +52,11 @@ func ResourceCluster() *schema.Resource {
 				Version: 1,
 				Type:    resourceClusterV1().CoreConfigSchema().ImpliedType(),
 				Upgrade: resourceClusterUpgradeV1,
+			},
+			{
+				Version: 2,
+				Type:    resourceClusterV2().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceClusterUpgradeV2,
 			},
 		},
 
@@ -189,6 +195,20 @@ func ResourceCluster() *schema.Resource {
 				Computed:    true,
 				Type:        schema.TypeInt,
 			},
+			"availability_zone_ids": {
+				Description: "List of Availability Zone IDs for the cluster nodes (e.g., " +
+					"'use1-az1', 'use1-az2', 'use1-az4' for AWS or 'us-central1-a', 'us-central1-b', " +
+					"'us-central1-c' for GCP). It is recommended to specify exactly 3 AZ IDs to " +
+					"ensure optimal distribution of nodes across availability zones. AZ IDs are " +
+					"consistent identifiers that map to the same physical availability zone across " +
+					"all accounts, unlike AZ names which may differ between accounts. If not " +
+					"specified, the server will automatically select availability zones.",
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -268,6 +288,33 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	clusterCreateRequest.InstanceID = mi.ID
+
+	// Handle availability zone IDs
+	if azIDs, ok := d.GetOk("availability_zone_ids"); ok {
+		// Figure out the cloud account ID; it's either BYOA or Scylla Account.
+		// There is a clear mapping from cloudProviderID to cloudAccountID.
+		cloudAccountID := clusterCreateRequest.AccountCredentialID
+		if cloudAccountID == 0 {
+			switch cloudProvider.CloudProvider.ID {
+			case 1: // AWS
+				cloudAccountID = 1
+			case 2: // GCP
+				cloudAccountID = 200
+			}
+		}
+
+		var azIDList []string
+		for _, v := range azIDs.([]interface{}) {
+			azIDList = append(azIDList, v.(string))
+		}
+		slices.Sort(azIDList)
+
+		if err := validateAvailabilityZoneIDs(ctx, scyllaClient, cloudAccountID, mr.ID, azIDList); err != nil {
+			return diag.FromErr(err)
+		}
+
+		clusterCreateRequest.AvailabilityZoneIDs = azIDList
+	}
 
 	if !versionOK {
 		clusterCreateRequest.ScyllaVersionID = scyllaClient.Meta.ScyllaVersions.DefaultScyllaVersionID
@@ -355,6 +402,16 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.Errorf("multi-datacenter clusters are not currently supported (found %d datacenters)", n)
 	}
 
+	// Only GetDataCenter returns the Topology field which contains AZ IDs.
+	// We set it to the existing cluster variable which is then used to
+	// set the KVs.
+	datacenter, err := scyllaClient.GetDataCenter(ctx, clusterID, cluster.Datacenter.ID)
+	if err != nil {
+		return diag.Errorf("failed to read datacenter %d: %s", cluster.Datacenter.ID, err)
+	}
+	cluster.Datacenter.Topology = datacenter.Topology
+	cluster.Datacenters[0].Topology = datacenter.Topology
+
 	var instanceExternalID string
 	if cluster.Datacenter.InstanceID != 0 {
 		instances, err := scyllaClient.ListCloudProviderInstancesPerRegion(ctx, cluster.CloudProviderID, cluster.Region.ID)
@@ -368,6 +425,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 		instanceExternalID = i.ExternalID
 	}
+
 	err = setClusterKVs(d, cluster, p.CloudProvider.Name, instanceExternalID)
 	if err != nil {
 		return diag.Errorf("failed to set cluster values for cluster %d: %s", cluster.ID, err)
@@ -422,6 +480,10 @@ func setClusterKVs(d *schema.ResourceData, cluster *model.Cluster, providerName,
 
 	if cluster.Instance != nil {
 		_ = d.Set("node_disk_size", cluster.Instance.TotalStorage)
+	}
+
+	if azIDs := cluster.Datacenter.AvailabilityZoneIDs(); len(azIDs) > 0 {
+		_ = d.Set("availability_zone_ids", azIDs)
 	}
 
 	return nil
@@ -652,4 +714,55 @@ func parseClusterID(d *schema.ResourceData) (int64, diag.Diagnostics) {
 		return 0, diag.Errorf("failed to parse a cluster ID %q: %s", d.Id(), err)
 	}
 	return clusterID, nil
+}
+
+// validateAvailabilityZoneIDs validates that the provided AZ IDs are valid for the given region.
+// TODO: When placement groups are supported through the API, revisit the minimum AZ requirement
+// as single-AZ deployments may become valid with placement group configuration.
+func validateAvailabilityZoneIDs(ctx context.Context, c *scylla.Client, cloudAccountID, regionID int64, azIDs []string) error {
+	if len(azIDs) < 2 {
+		return fmt.Errorf("at least 2 availability zone IDs are required, got %d", len(azIDs))
+	}
+
+	// Check for duplicate AZ IDs.
+	seen := make(map[string]struct{}, len(azIDs))
+	var duplicates []string
+	for _, azID := range azIDs {
+		if _, ok := seen[azID]; ok {
+			duplicates = append(duplicates, azID)
+		} else {
+			seen[azID] = struct{}{}
+		}
+	}
+	if len(duplicates) > 0 {
+		return fmt.Errorf("duplicate availability zone IDs are not allowed: %v", duplicates)
+	}
+
+	// Validate available AZ IDs.
+	availableAZs, err := c.ListAvailabilityZoneIDs(ctx, cloudAccountID, regionID)
+	if err != nil {
+		return fmt.Errorf("failed to list availability zones for region: %w", err)
+	}
+
+	availableSet := make(map[string]struct{}, len(availableAZs))
+	for _, az := range availableAZs {
+		availableSet[az] = struct{}{}
+	}
+
+	var invalidAZs []string
+	for _, azID := range azIDs {
+		if _, ok := availableSet[azID]; !ok {
+			invalidAZs = append(invalidAZs, azID)
+		}
+	}
+
+	if len(invalidAZs) > 0 {
+		return fmt.Errorf(
+			"invalid availability zone IDs %v; available AZ IDs for this region are: %v",
+			invalidAZs,
+			availableAZs,
+		)
+	}
+
+	return nil
 }

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -206,7 +206,7 @@ func ResourceCluster() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
@@ -338,6 +338,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("failed to read cluster %d: %s", cr.ClusterID, err)
 	}
 
+	if n := len(cluster.Datacenters); n != 1 {
+		return diag.Errorf("clusters without datacenter or multi-datacenter clusters are not currently supported (found %d datacenters)", n)
+	}
+
 	// Only GetDataCenter returns the Topology field which contains AZ IDs.
 	// We set it to the existing cluster variable which is then used to
 	// set the KVs.
@@ -408,8 +412,8 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.Errorf("unexpected cloud provider %d for cluster %d", cluster.CloudProviderID, cluster.ID)
 	}
 
-	if n := len(cluster.Datacenters); n > 1 {
-		return diag.Errorf("multi-datacenter clusters are not currently supported (found %d datacenters)", n)
+	if n := len(cluster.Datacenters); n != 1 {
+		return diag.Errorf("clusters without datacenter or multi-datacenter clusters are not currently supported (found %d datacenters)", n)
 	}
 
 	// Only GetDataCenter returns the Topology field which contains AZ IDs.
@@ -492,9 +496,12 @@ func setClusterKVs(d *schema.ResourceData, cluster *model.Cluster, providerName,
 		_ = d.Set("node_disk_size", cluster.Instance.TotalStorage)
 	}
 
-	if azIDs := cluster.Datacenter.AvailabilityZoneIDs(); len(azIDs) > 0 {
-		_ = d.Set("availability_zone_ids", azIDs)
+	azIDs := cluster.Datacenter.AvailabilityZoneIDs()
+	if azIDs == nil {
+		// Prevent stale data in case the new value is empty or missing.
+		azIDs = []string{}
 	}
+	_ = d.Set("availability_zone_ids", azIDs)
 
 	return nil
 }
@@ -551,8 +558,8 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("failed to get the cluster with ID %d: %s", clusterID, err)
 	}
 
-	if n := len(cluster.Datacenters); n > 1 {
-		return diag.Errorf("multi-datacenter clusters are not currently supported (found %d datacenters for cluster %d)", n, clusterID)
+	if n := len(cluster.Datacenters); n != 1 {
+		return diag.Errorf("clusters without datacenter or multi-datacenter clusters are not currently supported (found %d datacenters)", n)
 	}
 
 	// Resize will fail if there is any ongoing cluster request.
@@ -730,8 +737,8 @@ func parseClusterID(d *schema.ResourceData) (int64, diag.Diagnostics) {
 // TODO: When placement groups are supported through the API, revisit the minimum AZ requirement
 // as single-AZ deployments may become valid with placement group configuration.
 func validateAvailabilityZoneIDs(ctx context.Context, c *scylla.Client, cloudAccountID, regionID int64, azIDs []string) error {
-	if len(azIDs) < 2 {
-		return fmt.Errorf("at least 2 availability zone IDs are required, got %d", len(azIDs))
+	if l := len(azIDs); l < 2 || l > 3 {
+		return fmt.Errorf("at least 2 and at most 3 availability zone IDs are required, got %d", l)
 	}
 
 	// Check for duplicate AZ IDs.

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -300,6 +300,8 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 				cloudAccountID = 1
 			case 2: // GCP
 				cloudAccountID = 200
+			default:
+				return diag.Errorf("unknown cloud provider ID %d", cloudProvider.CloudProvider.ID)
 			}
 		}
 

--- a/internal/provider/cluster/cluster_v2.go
+++ b/internal/provider/cluster/cluster_v2.go
@@ -1,0 +1,141 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// resourceClusterV2 returns the schema for cluster resource version 2.
+// This version does not include the availability_zone_ids field.
+func resourceClusterV2() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Computed: true,
+				Type:     schema.TypeInt,
+			},
+			"cloud": {
+				Optional: true,
+				ForceNew: true,
+				Default:  "AWS",
+				Type:     schema.TypeString,
+			},
+			"name": {
+				Required: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"region": {
+				Required: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"node_count": {
+				Computed: true,
+				Type:     schema.TypeInt,
+			},
+			"min_nodes": {
+				Required: true,
+				Type:     schema.TypeInt,
+				ValidateDiagFunc: func(v interface{}, path cty.Path) diag.Diagnostics {
+					value := v.(int)
+					if value < 3 {
+						return diag.Errorf("min_nodes must be at least 3, got %d", value)
+					}
+					if value%3 != 0 {
+						return diag.Errorf("min_nodes must be divisible by 3, got %d", value)
+					}
+					return nil
+				},
+			},
+			"byoa_id": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeInt,
+			},
+			"user_api_interface": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+				Default:  "CQL",
+			},
+			"alternator_write_isolation": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+				Default:  "only_rmw_uses_lwt",
+			},
+			"node_type": {
+				Required: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"node_dns_names": {
+				Computed: true,
+				Type:     schema.TypeSet,
+				Elem:     schema.TypeString,
+				Set:      schema.HashString,
+			},
+			"node_private_ips": {
+				Computed: true,
+				Type:     schema.TypeSet,
+				Elem:     schema.TypeString,
+				Set:      schema.HashString,
+			},
+			"cidr_block": {
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"scylla_version": {
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"enable_vpc_peering": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeBool,
+				Default:  true,
+			},
+			"enable_dns": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeBool,
+				Default:  true,
+			},
+			"request_id": {
+				Computed: true,
+				Type:     schema.TypeInt,
+			},
+			"datacenter": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"status": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"node_disk_size": {
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+				Type:     schema.TypeInt,
+			},
+		},
+	}
+}
+
+// resourceClusterUpgradeV2 migrates state from version 2 to version 3.
+// This migration adds the availability_zone_ids field which will be
+// populated on the next read from the server.
+func resourceClusterUpgradeV2(_ context.Context, rawState map[string]any, _ any) (map[string]any, error) {
+	// availability_zone_ids is a new computed+optional field.
+	// No migration needed - the field will be populated on the next read.
+	return rawState, nil
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -80,7 +80,7 @@ func TestAccScyllaDBCloudCluster_basicAWS(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"scylladbcloud_cluster.test",
 						tfjsonpath.New("availability_zone_ids"),
-						knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.SetExact([]knownvalue.Check{
 							knownvalue.StringExact("use1-az2"),
 							knownvalue.StringExact("use1-az4"),
 							knownvalue.StringExact("use1-az6"),
@@ -451,13 +451,7 @@ func testAccCheckScyllaDBCloudClusterExists(
 			return errors.Wrapf(err, "error retrieving cluster %d", clusterID)
 		}
 
-		datacenterResponse, err := client.GetDataCenter(ctx, clusterID, clusterResponse.Datacenter.ID)
-		if err != nil {
-			return errors.Wrapf(err, "error retrieving datacenter %d", clusterResponse.Datacenter.ID)
-		}
-
 		*cluster = *clusterResponse
-		cluster.Datacenter.Topology = datacenterResponse.Topology
 
 		return nil
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -64,6 +64,7 @@ func TestAccScyllaDBCloudCluster_basicAWS(t *testing.T) {
   min_nodes  = 3
   cidr_block = "10.0.1.0/24"
   enable_dns = true
+  availability_zone_ids = ["use1-az2", "use1-az4", "use1-az6"]
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -75,6 +76,15 @@ func TestAccScyllaDBCloudCluster_basicAWS(t *testing.T) {
 						"scylladbcloud_cluster.test",
 						tfjsonpath.New("node_count"),
 						knownvalue.Int32Exact(3),
+					),
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("availability_zone_ids"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("use1-az2"),
+							knownvalue.StringExact("use1-az4"),
+							knownvalue.StringExact("use1-az6"),
+						}),
 					),
 				},
 				Check: resource.ComposeTestCheckFunc(
@@ -226,88 +236,6 @@ func TestAccScyllaDBCloudCluster_scaleOutFromOutside(t *testing.T) {
 	})
 }
 
-func TestAccScyllaDBCloudCluster_basicAWSMigrationV1ToV2(t *testing.T) {
-	ctx := t.Context()
-	resourceName := acctest.RandomWithPrefix("basic-aws-migration-v1-to-v2")
-
-	var cluster model.Cluster
-
-	nodeCountCompare := statecheck.CompareValue(compare.ValuesSame())
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testAccCheckScyllaDBCloudClusterDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"scylladbcloud": {
-						// 1.9 is the last version that uses the v1 schema
-						// that is node_count instead of min_nodes.
-						//
-						// Note: Be careful about overwritting the provider with
-						// a local build in .terraformrc. If you do that,
-						// it will overwrite the selected version in this
-						// test case.
-						VersionConstraint: "1.9",
-						Source:            "scylladb/scylladbcloud",
-					},
-				},
-				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
-  name       = %[1]q
-  cloud      = "AWS"
-  region     = "us-east-1"
-  node_type  = "i3.large"
-  node_count = 3
-  cidr_block = "10.0.1.0/24"
-  enable_dns = true
-}`, resourceName),
-				ConfigStateChecks: []statecheck.StateCheck{
-					nodeCountCompare.AddStateValue(
-						"scylladbcloud_cluster.test",
-						tfjsonpath.New("node_count"),
-					),
-					statecheck.ExpectKnownValue(
-						"scylladbcloud_cluster.test",
-						tfjsonpath.New("node_count"),
-						knownvalue.Int32Exact(3),
-					),
-				},
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScyllaDBCloudClusterExists(ctx, "scylladbcloud_cluster.test", &cluster),
-				),
-			},
-			{
-				ProtoV5ProviderFactories: protoV5ProviderFactories,
-				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
-  name       = %[1]q
-  cloud      = "AWS"
-  region     = "us-east-1"
-  node_type  = "i3.large"
-  min_nodes  = 3
-  cidr_block = "10.0.1.0/24"
-  enable_dns = true
-}`, resourceName),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					nodeCountCompare.AddStateValue(
-						"scylladbcloud_cluster.test",
-						tfjsonpath.New("node_count"),
-					),
-					statecheck.ExpectKnownValue(
-						"scylladbcloud_cluster.test",
-						tfjsonpath.New("min_nodes"),
-						knownvalue.Int32Exact(3),
-					),
-				},
-			},
-		},
-	})
-}
-
 func TestAccScyllaDBCloudCluster_basicGCP(t *testing.T) {
 	ctx := t.Context()
 	resourceName := acctest.RandomWithPrefix("basic-gcp")
@@ -396,6 +324,88 @@ func TestAccScyllaDBCloudCluster_basicGCPBYOA(t *testing.T) {
 	})
 }
 
+func TestAccScyllaDBCloudCluster_migrationV1ToV2(t *testing.T) {
+	ctx := t.Context()
+	resourceName := acctest.RandomWithPrefix("basic-aws-migration-v1-to-v2")
+
+	var cluster model.Cluster
+
+	nodeCountCompare := statecheck.CompareValue(compare.ValuesSame())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckScyllaDBCloudClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"scylladbcloud": {
+						// 1.9 is the last version that uses the v1 schema
+						// that is node_count instead of min_nodes.
+						//
+						// Note: Be careful about overwritting the provider with
+						// a local build in .terraformrc. If you do that,
+						// it will overwrite the selected version in this
+						// test case.
+						VersionConstraint: "1.9",
+						Source:            "scylladb/scylladbcloud",
+					},
+				},
+				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
+  name       = %[1]q
+  cloud      = "AWS"
+  region     = "us-east-1"
+  node_type  = "i3.large"
+  node_count = 3
+  cidr_block = "10.0.1.0/24"
+  enable_dns = true
+}`, resourceName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					nodeCountCompare.AddStateValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("node_count"),
+					),
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("node_count"),
+						knownvalue.Int32Exact(3),
+					),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScyllaDBCloudClusterExists(ctx, "scylladbcloud_cluster.test", &cluster),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: protoV5ProviderFactories,
+				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
+  name       = %[1]q
+  cloud      = "AWS"
+  region     = "us-east-1"
+  node_type  = "i3.large"
+  min_nodes  = 3
+  cidr_block = "10.0.1.0/24"
+  enable_dns = true
+}`, resourceName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					nodeCountCompare.AddStateValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("node_count"),
+					),
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("min_nodes"),
+						knownvalue.Int32Exact(3),
+					),
+				},
+			},
+		},
+	})
+}
+
 var configureProviderOnce sync.Once
 
 func testAccPreCheck(t *testing.T) {
@@ -436,12 +446,18 @@ func testAccCheckScyllaDBCloudClusterExists(
 			return err
 		}
 
-		response, err := client.GetCluster(ctx, clusterID)
+		clusterResponse, err := client.GetCluster(ctx, clusterID)
 		if err != nil {
 			return errors.Wrapf(err, "error retrieving cluster %d", clusterID)
 		}
 
-		*cluster = *response
+		datacenterResponse, err := client.GetDataCenter(ctx, clusterID, clusterResponse.Datacenter.ID)
+		if err != nil {
+			return errors.Wrapf(err, "error retrieving datacenter %d", clusterResponse.Datacenter.ID)
+		}
+
+		*cluster = *clusterResponse
+		cluster.Datacenter.Topology = datacenterResponse.Topology
 
 		return nil
 	}

--- a/internal/scylla/endpoints.go
+++ b/internal/scylla/endpoints.go
@@ -3,6 +3,7 @@ package scylla
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 
 	"github.com/scylladb/terraform-provider-scylladbcloud/internal/scylla/model"
@@ -200,6 +201,26 @@ func (c *Client) GetClusterRequest(ctx context.Context, requestID int64) (model.
 	return result, err
 }
 
+func (c *Client) ListAvailabilityZoneIDs(ctx context.Context, cloudAccountID int64, regionID int64) ([]string, error) {
+	var result []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+
+	path := fmt.Sprintf("/account/%d/cloud-account/%d/region/%d/zones", c.AccountID, cloudAccountID, regionID)
+	if err := c.get(ctx, path, &result); err != nil {
+		return nil, err
+	}
+
+	azIDs := make([]string, 0, len(result))
+	for _, item := range result {
+		azIDs = append(azIDs, item.ID)
+	}
+	slices.Sort(azIDs)
+
+	return azIDs, nil
+}
+
 func (c *Client) ListAllowlistRules(ctx context.Context, clusterID int64) ([]model.AllowedIP, error) {
 	var result []model.AllowedIP
 
@@ -243,6 +264,12 @@ func (c *Client) ListDataCenters(ctx context.Context, clusterID int64) ([]model.
 	}
 
 	return result.Datacenters, nil
+}
+
+func (c *Client) GetDataCenter(ctx context.Context, clusterID, dcID int64) (result model.Datacenter, _ error) {
+	path := fmt.Sprintf("/account/%d/cluster/%d/dc/%d", c.AccountID, clusterID, dcID)
+	err := c.get(ctx, path, &result)
+	return result, err
 }
 
 func (c *Client) ListClusterNodes(ctx context.Context, clusterID int64) ([]model.Node, error) {

--- a/internal/scylla/endpoints.go
+++ b/internal/scylla/endpoints.go
@@ -62,9 +62,27 @@ func (c *Client) GetCluster(ctx context.Context, clusterID int64) (*model.Cluste
 	}
 
 	path := fmt.Sprintf("/account/%d/cluster/%d", c.AccountID, clusterID)
-	err := c.get(ctx, path, &result, "enriched", "true")
+	if err := c.get(ctx, path, &result, "enriched", "true"); err != nil {
+		return nil, err
+	}
 
-	return &result.Cluster, err
+	cluster := &result.Cluster
+
+	// Fetch datacenter topology if we have exactly one datacenter.
+	// The GetCluster API doesn't return the Topology field which contains
+	// availability zone IDs - we need to fetch it separately via GetDataCenter.
+	if len(cluster.Datacenters) != 1 {
+		return nil, fmt.Errorf("only single datacenter clusters are supported; got %d datacenters", len(cluster.Datacenters))
+	}
+
+	datacenter, err := c.GetDataCenter(ctx, clusterID, cluster.Datacenter.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read datacenter %d: %w", cluster.Datacenter.ID, err)
+	}
+	cluster.Datacenter.Topology = datacenter.Topology
+	cluster.Datacenters[0].Topology = datacenter.Topology
+
+	return cluster, nil
 }
 
 func (c *Client) Bundle(ctx context.Context, clusterID int64) ([]byte, error) {

--- a/internal/scylla/model/model.go
+++ b/internal/scylla/model/model.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 	"time"
 )
@@ -91,6 +92,7 @@ type ClusterRequest struct {
 type ClusterCreateRequest struct {
 	AccountCredentialID      int64    `json:"accountCredentialId,omitempty"`
 	AlternatorWriteIsolation string   `json:"alternatorWriteIsolation,omitempty"`
+	AvailabilityZoneIDs      []string `json:"availabilityZoneIdsOverride,omitempty"`
 	BroadcastType            string   `json:"broadcastType,omitempty"`
 	CidrBlock                string   `json:"cidrBlock,omitempty"`
 	CloudProviderID          int64    `json:"cloudProviderId,omitempty"`
@@ -174,6 +176,29 @@ type Datacenter struct {
 	AccountCloudProviderCredentialID int64                `json:"accountCloudProviderCredentialsId"`
 	CloudProvider                    *CloudProvider       `json:"cloudProvider,omitempty"`
 	Region                           *CloudProviderRegion `json:"region,omitempty"`
+	Topology                         *Topology            `json:"Topology,omitempty"`
+}
+
+func (d Datacenter) AvailabilityZoneIDs() []string {
+	if d.Topology == nil {
+		return nil
+	}
+	var azIDs []string
+	for _, rack := range d.Topology.Racks {
+		azIDs = append(azIDs, rack.ZoneID)
+	}
+	slices.Sort(azIDs)
+	return azIDs
+}
+
+type Topology struct {
+	Racks []Rack `json:"Racks"`
+}
+
+type Rack struct {
+	Name     string `json:"Name"`
+	ZoneID   string `json:"ZoneID"`
+	ZoneName string `json:"ZoneName"`
 }
 
 type AllowedIP struct {


### PR DESCRIPTION
This change allows to specify `availability_zone_ids` in the configuration.

Currently, the two variations are possible:
- Two different AZ IDs
- Three different AZ IDs

In the follow-up, it will be possible to specify a single AZ ID but under a condition of using [the placement groups](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html).