### PR TITLE
fix(cluster): resolve cloud account ID dynamically

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Git Commits
+
+Only create commits when explicitly asked. Do not commit
+automatically after completing a task.
+
+Follow standard git commit message formatting rules.
+
+**Subject line (first line)**
+- 50 characters or fewer; never exceed 72
+- Imperative mood: "add", "fix", "rename" — not "added" or "fixes"
+- No trailing period
+- Use conventional commits format: `type(scope): subject`
+
+**Blank line**
+- Always separate subject from body with a blank line
+
+**Body lines**
+- Hard wrap at 72 characters — no line may exceed 72 chars
+- Explain *what* and *why*, not *how*
+
+These limits ensure correct rendering in `git log`, `git format-patch`,
+GitHub, and 80-column terminals.

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -292,17 +292,22 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	// Handle availability zone IDs
 	if azIDs, ok := d.GetOk("availability_zone_ids"); ok {
 		// Figure out the cloud account ID; it's either BYOA or Scylla Account.
-		// There is a clear mapping from cloudProviderID to cloudAccountID.
+		// If cloudAccountID is 0, we look up the active cloud account owned by Scylla.
 		cloudAccountID := clusterCreateRequest.AccountCredentialID
 		if cloudAccountID == 0 {
-			switch cloudProvider.CloudProvider.ID {
-			case 1: // AWS
-				cloudAccountID = 1
-			case 2: // GCP
-				cloudAccountID = 200
-			default:
-				return diag.Errorf("unknown cloud provider ID %d", cloudProvider.CloudProvider.ID)
+			cloudAccounts, err := scyllaClient.ListCloudAccounts(ctx)
+			if err != nil {
+				return diag.Errorf("failed to list cloud accounts: %s", err)
 			}
+
+			ca := model.FindScyllaCloudAccount(cloudAccounts, cloudProvider.CloudProvider.ID)
+			if ca == nil {
+				return diag.Errorf(
+					"no active Scylla-owned cloud account found for cloud provider %q (ID %d)",
+					cloud, cloudProvider.CloudProvider.ID,
+				)
+			}
+			cloudAccountID = ca.ID
 		}
 
 		azIDsSet := azIDs.(*schema.Set)

--- a/internal/scylla/endpoints.go
+++ b/internal/scylla/endpoints.go
@@ -219,6 +219,17 @@ func (c *Client) GetClusterRequest(ctx context.Context, requestID int64) (model.
 	return result, err
 }
 
+func (c *Client) ListCloudAccounts(ctx context.Context) ([]model.CloudAccount, error) {
+	var result []model.CloudAccount
+
+	path := fmt.Sprintf("/account/%d/cloud-account", c.AccountID)
+	if err := c.get(ctx, path, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (c *Client) ListAvailabilityZoneIDs(ctx context.Context, cloudAccountID int64, regionID int64) ([]string, error) {
 	var result []struct {
 		ID   string `json:"id"`

--- a/internal/scylla/model/model.go
+++ b/internal/scylla/model/model.go
@@ -13,6 +13,24 @@ type CloudProvider struct {
 	RootAccountID string `json:"rootAccountID"`
 }
 
+type CloudAccount struct {
+	ID              int64  `json:"id"`
+	CloudProviderID int64  `json:"cloudProviderId"`
+	Owner           string `json:"owner"`
+	State           string `json:"state"`
+}
+
+// FindScyllaCloudAccount returns the active Scylla-owned cloud account
+// for the given cloud provider ID, or nil if none is found.
+func FindScyllaCloudAccount(accounts []CloudAccount, cloudProviderID int64) *CloudAccount {
+	for _, ca := range accounts {
+		if ca.CloudProviderID == cloudProviderID && ca.Owner == "Scylla" && ca.State == "ACTIVE" {
+			return &ca
+		}
+	}
+	return nil
+}
+
 type CloudProviders struct {
 	CloudProviders []CloudProvider `json:"cloudProviders"`
 }


### PR DESCRIPTION
Replace hardcoded cloud account IDs (AWS=1, GCP=200) with a dynamic
lookup via the /account/{id}/cloud-account API endpoint, matching by
cloud provider ID, owner, and active state. This ensures correctness
across different environments where IDs may differ.