### PR TITLE
feat(cluster): support single availability zone deployments

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,19 @@ provider "scylladbcloud" {
 }
 ```
 
+### Creating a Cluster
+
+```terraform
+resource "scylladbcloud_cluster" "example" {
+  name       = "my-cluster"
+  cloud      = "AWS"
+  region     = "us-east-1"
+  node_type  = "i3.large"
+  min_nodes  = 3
+  cidr_block = "10.0.1.0/24"
+}
+```
+
 ### Environment Variables
 
 Authentication token can be provided by using the `SCYLLADB_CLOUD_TOKEN` environment variable.

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -47,7 +47,7 @@ output "scylladbcloud_cluster_datacenter" {
 ### Optional
 
 - `alternator_write_isolation` (String) Default write isolation policy
-- `availability_zone_ids` (List of String) List of Availability Zone IDs for the cluster nodes (e.g., 'use1-az1', 'use1-az2', 'use1-az4' for AWS or 'us-central1-a', 'us-central1-b', 'us-central1-c' for GCP). It is recommended to specify exactly 3 AZ IDs to ensure optimal distribution of nodes across availability zones. AZ IDs are consistent identifiers that map to the same physical availability zone across all accounts, unlike AZ names which may differ between accounts. If not specified, the server will automatically select availability zones.
+- `availability_zone_ids` (Set of String) List of Availability Zone IDs for the cluster nodes (e.g., 'use1-az1', 'use1-az2', 'use1-az4' for AWS or 'us-central1-a', 'us-central1-b', 'us-central1-c' for GCP). Between 1 and 3 AZ IDs can be specified. It is recommended to specify exactly 3 AZ IDs to ensure optimal distribution of nodes across availability zones. AZ IDs are consistent identifiers that map to the same physical availability zone across all accounts, unlike AZ names which may differ between accounts. If not specified, the server will automatically select availability zones.
 - `byoa_id` (Number) BYOA credential ID (only for AWS)
 - `cidr_block` (String) IPv4 CIDR of the cluster
 - `cloud` (String) Cloud provider (AWS, GCP)

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -198,11 +198,12 @@ func ResourceCluster() *schema.Resource {
 			"availability_zone_ids": {
 				Description: "List of Availability Zone IDs for the cluster nodes (e.g., " +
 					"'use1-az1', 'use1-az2', 'use1-az4' for AWS or 'us-central1-a', 'us-central1-b', " +
-					"'us-central1-c' for GCP). It is recommended to specify exactly 3 AZ IDs to " +
-					"ensure optimal distribution of nodes across availability zones. AZ IDs are " +
-					"consistent identifiers that map to the same physical availability zone across " +
-					"all accounts, unlike AZ names which may differ between accounts. If not " +
-					"specified, the server will automatically select availability zones.",
+					"'us-central1-c' for GCP). Between 1 and 3 AZ IDs can be specified. It is " +
+					"recommended to specify exactly 3 AZ IDs to ensure optimal distribution of " +
+					"nodes across availability zones. AZ IDs are consistent identifiers that map " +
+					"to the same physical availability zone across all accounts, unlike AZ names " +
+					"which may differ between accounts. If not specified, the server will " +
+					"automatically select availability zones.",
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
@@ -223,6 +224,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			NumberOfNodes:        int64(d.Get("min_nodes").(int)),
 			UserAPIInterface:     d.Get("user_api_interface").(string),
 			EnableDNSAssociation: d.Get("enable_dns").(bool),
+			Placement:            "true",
 		}
 		cloud                        = d.Get("cloud").(string)
 		cidr, cidrOK                 = d.GetOk("cidr_block")
@@ -723,11 +725,9 @@ func parseClusterID(d *schema.ResourceData) (int64, diag.Diagnostics) {
 }
 
 // validateAvailabilityZoneIDs validates that the provided AZ IDs are valid for the given region.
-// TODO: When placement groups are supported through the API, revisit the minimum AZ requirement
-// as single-AZ deployments may become valid with placement group configuration.
 func validateAvailabilityZoneIDs(ctx context.Context, c *scylla.Client, cloudAccountID, regionID int64, azIDs []string) error {
-	if l := len(azIDs); l < 2 || l > 3 {
-		return fmt.Errorf("at least 2 and at most 3 availability zone IDs are required, got %d", l)
+	if l := len(azIDs); l < 1 || l > 3 {
+		return fmt.Errorf("at least 1 and at most 3 availability zone IDs are required, got %d", l)
 	}
 
 	// Check for duplicate AZ IDs.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -95,6 +95,55 @@ func TestAccScyllaDBCloudCluster_basicAWS(t *testing.T) {
 	})
 }
 
+func TestAccScyllaDBCloudCluster_basicAWSSingleAZ(t *testing.T) {
+	ctx := t.Context()
+	resourceName := acctest.RandomWithPrefix("basic-aws-single-az")
+
+	var cluster model.Cluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: protoV5ProviderFactories,
+		CheckDestroy:             testAccCheckScyllaDBCloudClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
+  name       = %[1]q
+  cloud      = "AWS"
+  region     = "us-east-1"
+  node_type  = "i3.large"
+  min_nodes  = 3
+  cidr_block = "10.0.1.0/24"
+  enable_dns = true
+  availability_zone_ids = ["use1-az2"]
+}`, resourceName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("min_nodes"),
+						knownvalue.Int32Exact(3),
+					),
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("node_count"),
+						knownvalue.Int32Exact(3),
+					),
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("availability_zone_ids"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("use1-az2"),
+						}),
+					),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScyllaDBCloudClusterExists(ctx, "scylladbcloud_cluster.test", &cluster),
+				),
+			},
+		},
+	})
+}
+
 func TestAccScyllaDBCloudCluster_basicAWSScaleOut(t *testing.T) {
 	ctx := t.Context()
 	resourceName := acctest.RandomWithPrefix("basic-aws-scale-out")

--- a/internal/scylla/model/model.go
+++ b/internal/scylla/model/model.go
@@ -129,6 +129,7 @@ type ClusterCreateRequest struct {
 	Provisioning             string   `json:"provisioning,omitempty"`
 	ProcessingUnits          int      `json:"pu,omitempty" minimum:"1" maximum:"1000" default:"1"`
 	Expiration               string   `json:"expiration,omitempty" example:"12"`
+	Placement                string   `json:"placement,omitempty"`
 }
 
 type Cluster struct {


### PR DESCRIPTION
Enable placement groups by default on cluster creation,
allowing clusters to be deployed into a single availability
zone. Previously, at least 2 AZ IDs were required.