### PR TITLE
feature(xcloud): add support update xcloud scaling policies

### DIFF
--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -167,6 +168,65 @@ func flattenScaling(raw *model.Scaling, instances []model.CloudProviderInstance,
 	}
 
 	return []map[string]interface{}{block}, nil
+}
+
+func isScalingEqual(lhs, rhs *model.Scaling) bool {
+	if lhs == nil || !lhs.Enabled() {
+		lhs = nil
+	}
+	if rhs == nil || !rhs.Enabled() {
+		rhs = nil
+	}
+
+	if lhs == nil || rhs == nil {
+		return lhs == rhs
+	}
+
+	if lhs.Mode != rhs.Mode {
+		return false
+	}
+	if !slices.Equal(lhs.InstanceFamilies, rhs.InstanceFamilies) {
+		return false
+	}
+	if !slices.Equal(lhs.InstanceTypeIDs, rhs.InstanceTypeIDs) {
+		return false
+	}
+
+	return isScalingPoliciesEqual(lhs.Policies, rhs.Policies)
+}
+
+func isScalingPoliciesEqual(lhs, rhs *model.ScalingPolicies) bool {
+	if lhs == nil || rhs == nil {
+		return lhs == rhs
+	}
+	if !isScalingStoragePolicyEqual(lhs.Storage, rhs.Storage) {
+		return false
+	}
+	if !isScalingVCPUPolicyEqual(lhs.VCPU, rhs.VCPU) {
+		return false
+	}
+	return true
+}
+
+func isScalingStoragePolicyEqual(lhs, rhs *model.ScalingStoragePolicy) bool {
+	if lhs == nil || rhs == nil {
+		return lhs == rhs
+	}
+	return lhs.Min == rhs.Min && lhs.TargetUtilization == rhs.TargetUtilization
+}
+
+func isScalingVCPUPolicyEqual(lhs, rhs *model.ScalingVCPUPolicy) bool {
+	if lhs == nil || rhs == nil {
+		return lhs == rhs
+	}
+	return lhs.Min == rhs.Min
+}
+
+func clusterInstancesForRegion(ctx context.Context, c *scylla.Client, cluster *model.Cluster) ([]model.CloudProviderInstance, error) {
+	if cluster == nil || cluster.Region == nil {
+		return nil, errors.New("cluster region is required")
+	}
+	return c.ListCloudProviderInstancesPerRegion(ctx, cluster.CloudProviderID, cluster.Region.ID)
 }
 
 func hasScaling(cluster *model.Cluster) bool {
@@ -749,6 +809,7 @@ func setClusterKVs(d *schema.ResourceData, cluster *model.Cluster, providerName,
 	}
 
 	_ = d.Set("user_api_interface", cluster.UserAPIInterface)
+
 	if !hasScaling(cluster) {
 		_ = d.Set("node_type", instanceExternalID)
 	}
@@ -785,6 +846,9 @@ func setClusterKVs(d *schema.ResourceData, cluster *model.Cluster, providerName,
 
 func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	scyllaClient := meta.(*scylla.Client)
+	if d.HasChange("scaling") {
+		return resourceClusterUpdateScaling(ctx, d, scyllaClient)
+	}
 
 	// Currently, only min_nodes is updatable.
 	if !d.HasChange("min_nodes") {
@@ -891,6 +955,72 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	return resourceClusterRead(ctx, d, meta)
+}
+
+func resourceClusterUpdateScaling(ctx context.Context, d *schema.ResourceData, scyllaClient *scylla.Client) diag.Diagnostics {
+	clusterID, diags := parseClusterID(d)
+	if diags != nil {
+		return diags
+	}
+
+	cluster, err := scyllaClient.GetCluster(ctx, clusterID)
+	if err != nil {
+		if scylla.IsClusterDeletedErr(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("failed to get the cluster with ID %d: %s", clusterID, err)
+	}
+
+	if n := len(cluster.Datacenters); n != 1 {
+		return diag.Errorf("clusters without datacenter or multi-datacenter clusters are not currently supported (found %d datacenters)", n)
+	}
+
+	instances, err := clusterInstancesForRegion(ctx, scyllaClient, cluster)
+	if err != nil {
+		return diag.Errorf("failed to list cloud provider instances: %s", err)
+	}
+
+	cloudProvider := scyllaClient.Meta.ProviderByID(cluster.CloudProviderID)
+	if cloudProvider == nil {
+		return diag.Errorf("unexpected cloud provider %d for cluster %d", cluster.CloudProviderID, cluster.ID)
+	}
+
+	desiredScaling, err := expandScaling(d.Get("scaling"), cluster.Region.ExternalID, instances, cloudProvider)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if desiredScaling == nil {
+		return diag.Errorf("scaling block must be configured for scaling updates")
+	}
+	remoteScaling := cluster.Datacenters[0].Scaling
+
+	if !hasScaling(cluster) {
+		return diag.Errorf("scaling updates are supported only for X Cloud clusters")
+	}
+
+	if isScalingEqual(desiredScaling, remoteScaling) {
+		return resourceClusterRead(ctx, d, scyllaClient)
+	}
+
+	request, err := scyllaClient.UpdateDcScalingPolicy(ctx, cluster.ID, cluster.Datacenter.ID, desiredScaling)
+	if err != nil {
+		var apiErr *scylla.APIError
+		if errors.As(err, &apiErr) && apiErr.Code == "041008" {
+			return diag.Errorf("X-Cloud clusters do not support manual resizing. Use the scaling block to adjust capacity policies.")
+		}
+		return diag.Errorf("failed to update cluster scaling: %s", err)
+	}
+
+	if request == nil || request.ID == 0 {
+		return diag.Errorf("failed to update cluster scaling: missing cluster request ID in response")
+	}
+
+	if err := WaitForClusterRequestID(ctx, scyllaClient, request.ID); err != nil {
+		return diag.Errorf("failed waiting for scaling update request %d for cluster %d: %s", request.ID, cluster.ID, err)
+	}
+
+	return resourceClusterRead(ctx, d, scyllaClient)
 }
 
 func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -843,11 +843,11 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		return resourceClusterUpdateScaling(ctx, d, scyllaClient)
 	}
 
-	if !d.HasChange("min_nodes") {
-		return nil
+	if d.HasChange("min_nodes") {
+		return resourceClusterUpdateMinNodes(ctx, d, meta, scyllaClient)
 	}
 
-	return resourceClusterUpdateMinNodes(ctx, d, meta, scyllaClient)
+	return nil
 }
 
 func resourceClusterUpdateMinNodes(ctx context.Context, d *schema.ResourceData, meta interface{}, scyllaClient *scylla.Client) diag.Diagnostics {

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -222,13 +222,6 @@ func isScalingVCPUPolicyEqual(lhs, rhs *model.ScalingVCPUPolicy) bool {
 	return lhs.Min == rhs.Min
 }
 
-func clusterInstancesForRegion(ctx context.Context, c *scylla.Client, cluster *model.Cluster) ([]model.CloudProviderInstance, error) {
-	if cluster == nil || cluster.Region == nil {
-		return nil, errors.New("cluster region is required")
-	}
-	return c.ListCloudProviderInstancesPerRegion(ctx, cluster.CloudProviderID, cluster.Region.ID)
-}
-
 func hasScaling(cluster *model.Cluster) bool {
 	if cluster == nil {
 		return false
@@ -855,6 +848,10 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		return nil
 	}
 
+	return resourceClusterUpdateMinNodes(ctx, d, meta, scyllaClient)
+}
+
+func resourceClusterUpdateMinNodes(ctx context.Context, d *schema.ResourceData, meta interface{}, scyllaClient *scylla.Client) diag.Diagnostics {
 	// There are three scenarios:
 	// - scale-out: newMinNodes > oldMinNodes
 	// - scale-in: newMinNodes < oldMinNodes
@@ -976,7 +973,7 @@ func resourceClusterUpdateScaling(ctx context.Context, d *schema.ResourceData, s
 		return diag.Errorf("clusters without datacenter or multi-datacenter clusters are not currently supported (found %d datacenters)", n)
 	}
 
-	instances, err := clusterInstancesForRegion(ctx, scyllaClient, cluster)
+	instances, err := scyllaClient.ListCloudProviderInstancesPerRegion(ctx, cluster.CloudProviderID, cluster.Region.ID)
 	if err != nil {
 		return diag.Errorf("failed to list cloud provider instances: %s", err)
 	}

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -843,7 +843,6 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		return resourceClusterUpdateScaling(ctx, d, scyllaClient)
 	}
 
-	// Currently, only min_nodes is updatable.
 	if !d.HasChange("min_nodes") {
 		return nil
 	}

--- a/internal/provider/cluster/cluster_test.go
+++ b/internal/provider/cluster/cluster_test.go
@@ -375,3 +375,54 @@ func TestSetClusterKVsSetsScaling(t *testing.T) {
 	require.Zero(t, data.Get("min_nodes"))
 	require.Empty(t, data.Get("node_type"))
 }
+
+func TestIsScalingEqual(t *testing.T) {
+	t.Parallel()
+
+	base := &model.Scaling{
+		Mode:            model.ScalingXCloud,
+		InstanceTypeIDs: []int64{2},
+		Policies: &model.ScalingPolicies{
+			Storage: &model.ScalingStoragePolicy{Min: 500, TargetUtilization: 0.75},
+			VCPU:    &model.ScalingVCPUPolicy{Min: 8},
+		},
+	}
+
+	tests := []struct {
+		name string
+		lhs  *model.Scaling
+		rhs  *model.Scaling
+		want bool
+	}{
+		{name: "both nil", want: true},
+		{name: "same scaling", lhs: base, rhs: base, want: true},
+		{
+			name: "different instance type ids",
+			lhs:  base,
+			rhs: &model.Scaling{
+				Mode:            model.ScalingXCloud,
+				InstanceTypeIDs: []int64{3},
+				Policies:        base.Policies,
+			},
+		},
+		{
+			name: "different storage min",
+			lhs:  base,
+			rhs: &model.Scaling{
+				Mode:            model.ScalingXCloud,
+				InstanceTypeIDs: []int64{2},
+				Policies: &model.ScalingPolicies{
+					Storage: &model.ScalingStoragePolicy{Min: 750, TargetUtilization: 0.75},
+					VCPU:    &model.ScalingVCPUPolicy{Min: 8},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, isScalingEqual(tt.lhs, tt.rhs))
+		})
+	}
+}

--- a/internal/scylla/client.go
+++ b/internal/scylla/client.go
@@ -263,6 +263,10 @@ func (c *Client) delete(ctx context.Context, path string) error {
 	return c.retryCall(ctx, http.MethodDelete, path, nil, nil)
 }
 
+func (c *Client) put(ctx context.Context, path string, requestBody, resultType interface{}) error {
+	return c.retryCall(ctx, http.MethodPut, path, requestBody, resultType)
+}
+
 func (c *Client) findAndSaveAccountID(ctx context.Context) error {
 	var result struct {
 		AccountID int64 `json:"accountId"`

--- a/internal/scylla/endpoints.go
+++ b/internal/scylla/endpoints.go
@@ -79,7 +79,9 @@ func (c *Client) GetCluster(ctx context.Context, clusterID int64) (*model.Cluste
 	if err != nil {
 		return nil, fmt.Errorf("failed to read datacenter %d: %w", cluster.Datacenter.ID, err)
 	}
+	cluster.Datacenter.Scaling = datacenter.Scaling
 	cluster.Datacenter.Topology = datacenter.Topology
+	cluster.Datacenters[0].Scaling = datacenter.Scaling
 	cluster.Datacenters[0].Topology = datacenter.Topology
 
 	return cluster, nil
@@ -164,6 +166,17 @@ func (c *Client) ResizeCluster(ctx context.Context, clusterID int64, dcID int64,
 	if err := c.post(ctx, path, data, &result); err != nil {
 		return nil, err
 	}
+	return &result, nil
+}
+
+func (c *Client) UpdateDcScalingPolicy(ctx context.Context, clusterID, dcID int64, scaling *model.Scaling) (*model.ClusterRequest, error) {
+	var result model.ClusterRequest
+
+	path := fmt.Sprintf("/account/%d/cluster/%d/dc/%d/scaling", c.AccountID, clusterID, dcID)
+	if err := c.put(ctx, path, scaling, &result); err != nil {
+		return nil, err
+	}
+
 	return &result, nil
 }
 


### PR DESCRIPTION
This PR aims to add support to change scaling policies.

If apply detects that there are no changes needed but the state file is out of sync it will reconciliate and update it

closes: CLOUD-1535

note: changing scaling policies does not mean that there will certainly be a cluster shape change