### PR TITLE
Fix respecting scylla_version in the cluster resource

### DIFF
--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -656,7 +656,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	if !versionOK {
 		clusterCreateRequest.ScyllaVersionID = scyllaClient.Meta.ScyllaVersions.DefaultScyllaVersionID
 	} else if mv := scyllaClient.Meta.VersionByName(version.(string)); mv != nil {
-		clusterCreateRequest.ScyllaVersionID = mv.VersionID
+		clusterCreateRequest.ScyllaVersionID = mv.ID
 	} else {
 		return diag.Errorf(`unrecognized value %q for "scylla_version" attribute`, version)
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -57,13 +57,14 @@ func TestAccScyllaDBCloudCluster_basicAWS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
-  name       = %[1]q
-  cloud      = "AWS"
-  region     = "us-east-1"
-  node_type  = "i3.large"
-  min_nodes  = 3
-  cidr_block = "10.0.1.0/24"
-  enable_dns = true
+  name           = %[1]q
+  cloud          = "AWS"
+  region         = "us-east-1"
+  node_type      = "i3.large"
+  min_nodes      = 3
+  scylla_version = "2026.1.1"
+  cidr_block     = "10.0.1.0/24"
+  enable_dns     = true
   availability_zone_ids = ["use1-az2", "use1-az4", "use1-az6"]
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -86,9 +87,24 @@ func TestAccScyllaDBCloudCluster_basicAWS(t *testing.T) {
 							knownvalue.StringExact("use1-az6"),
 						}),
 					),
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("scylla_version"),
+						knownvalue.StringExact("2026.1.1"),
+					),
 				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScyllaDBCloudClusterExists(ctx, "scylladbcloud_cluster.test", &cluster),
+					func(s *terraform.State) error {
+						if cluster.ScyllaVersion == nil {
+							return fmt.Errorf("cluster ScyllaVersion is nil")
+						}
+						if cluster.ScyllaVersion.Version != "2026.1.1" {
+							return fmt.Errorf("expected scylla_version %q, got %q",
+								"2026.1.1", cluster.ScyllaVersion.Version)
+						}
+						return nil
+					},
 				),
 			},
 		},

--- a/internal/scylla/cloudmeta.go
+++ b/internal/scylla/cloudmeta.go
@@ -153,7 +153,7 @@ func (m *Cloudmeta) DefaultVersion() *model.ScyllaVersion {
 func (m *Cloudmeta) VersionByID(id int64) *model.ScyllaVersion {
 	for i := range m.ScyllaVersions.ScyllaVersions {
 		v := &m.ScyllaVersions.ScyllaVersions[i]
-		if v.VersionID == id {
+		if v.ID == id {
 			return v
 		}
 	}

--- a/internal/scylla/model/model.go
+++ b/internal/scylla/model/model.go
@@ -42,7 +42,7 @@ type CloudProviders struct {
 }
 
 type ScyllaVersion struct {
-	VersionID   int64  `json:"versionId"`
+	ID          int64  `json:"id"`
 	Version     string `json:"version"`
 	Description string `json:"description"`
 	NewCluster  string `json:"newCluster"`


### PR DESCRIPTION
Regression introduced in https://github.com/scylladb/terraform-provider-scylladbcloud/commit/d77aee4ef8709cb8606f2572ba6c9898a17ef95c#diff-61cb810882acfb41bbb98dc0ed86ef6c8fac027b447833db7f62c78bf235963eR20.

Fixes CLOUD-1792