### PR TITLE
feat(cluster): add backup_retention_days parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ resource "scylladbcloud_cluster" "standard" {
   node_type  = "i3.large"
   min_nodes  = 3
   cidr_block = "172.31.0.0/16"
+
+  # Set to 0 to delete backups immediately after cluster deletion.
+  # Defaults to 1 to prevent accidental data loss.
+  backup_retention_days = 1
 }
 ```
 
@@ -58,6 +62,10 @@ resource "scylladbcloud_cluster" "xcloud" {
   cloud      = "AWS"
   region     = "us-east-1"
   cidr_block = "172.31.0.0/16"
+
+  # Set to 0 to delete backups immediately after cluster deletion.
+  # Defaults to 1 to prevent accidental data loss.
+  backup_retention_days = 1
 
   scaling {
     instance_families = ["i8g"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,10 @@ resource "scylladbcloud_cluster" "standard" {
   node_type  = "i3.large"
   min_nodes  = 3
   cidr_block = "10.0.1.0/24"
+
+  # Set to 0 to delete backups immediately after cluster deletion.
+  # Defaults to 1 to prevent accidental data loss.
+  backup_retention_days = 1
 }
 ```
 
@@ -63,6 +67,10 @@ resource "scylladbcloud_cluster" "xcloud" {
   cloud      = "AWS"
   region     = "us-east-1"
   cidr_block = "10.0.1.0/24"
+
+  # Set to 0 to delete backups immediately after cluster deletion.
+  # Defaults to 1 to prevent accidental data loss.
+  backup_retention_days = 1
 
   scaling {
     instance_families = ["i8g"]

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -46,6 +46,7 @@ output "scylladbcloud_cluster_datacenter" {
 
 - `alternator_write_isolation` (String) The write isolation policy. Used only for the ALTERNATOR API interface.
 - `availability_zone_ids` (Set of String) Availability zone IDs where cluster nodes are provisioned. Provide exactly 3 distinct AZ IDs (e.g. ["use1-az1", "use1-az4", "use1-az5"]). If omitted, zones are selected automatically. After refreshing state with terraform refresh, you can read back the IDs that were assigned.
+- `backup_retention_days` (Number) Number of days to retain backups after cluster deletion (0-60). If set to 0, backups are deleted immediately. Defaults to 1 to prevent accidental data loss.
 - `byoa_id` (Number) The ID of your account (BYOA) in ScyllaDB Cloud (only for AWS).
 - `cidr_block` (String) The CIDR block for the cluster network.
 - `cloud` (String) The cloud provider. Accepted values: AWS, GCP.

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -46,7 +46,7 @@ output "scylladbcloud_cluster_datacenter" {
 
 - `alternator_write_isolation` (String) The write isolation policy. Used only for the ALTERNATOR API interface.
 - `availability_zone_ids` (Set of String) Availability zone IDs where cluster nodes are provisioned. Provide exactly 3 distinct AZ IDs (e.g. ["use1-az1", "use1-az4", "use1-az5"]). If omitted, zones are selected automatically. After refreshing state with terraform refresh, you can read back the IDs that were assigned.
-- `backup_retention_days` (Number) Number of days to retain backups after cluster deletion (0-60). If set to 0, backups are deleted immediately. Defaults to 1 to prevent accidental data loss.
+- `backup_retention_days` (Number) The number of days to retain backups after deleting the cluster between 0 and 60. If set to 0, backups are deleted immediately. Defaults to 1 to prevent accidental data loss.
 - `byoa_id` (Number) The ID of your account (BYOA) in ScyllaDB Cloud (only for AWS).
 - `cidr_block` (String) The CIDR block for the cluster network.
 - `cloud` (String) The cloud provider. Accepted values: AWS, GCP.

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -527,7 +527,7 @@ func ResourceCluster() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"backup_retention_days": {
-				Description: "Number of days to retain backups after cluster deletion (0-60). " +
+				Description: "The number of days to retain backups after deleting the cluster between 0 and 60. " +
 					"If set to 0, backups are deleted immediately. " +
 					"Defaults to 1 to prevent accidental data loss.",
 				Optional:         true,

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -43,6 +43,14 @@ func validateScalingTargetUtilizationDiag(v interface{}, _ cty.Path) diag.Diagno
 	return nil
 }
 
+func validateBackupRetentionDaysDiag(v interface{}, _ cty.Path) diag.Diagnostics {
+	value := v.(int)
+	if value < 0 || value > 60 {
+		return diag.Errorf("backup_retention_days must be between 0 and 60, got %d", value)
+	}
+	return nil
+}
+
 func castToNestedBlock(raw interface{}) (map[string]interface{}, bool) {
 	items, ok := raw.([]interface{})
 	if !ok || len(items) == 0 || items[0] == nil {
@@ -517,6 +525,15 @@ func ResourceCluster() *schema.Resource {
 				ForceNew: true,
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"backup_retention_days": {
+				Description: "Number of days to retain backups after cluster deletion (0-60). " +
+					"If set to 0, backups are deleted immediately. " +
+					"Defaults to 1 to prevent accidental data loss.",
+				Optional:         true,
+				Type:             schema.TypeInt,
+				Default:          1,
+				ValidateDiagFunc: validateBackupRetentionDaysDiag,
 			},
 		},
 	}
@@ -1037,7 +1054,9 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("failed to read the cluster name from the resource")
 	}
 
-	r, err := c.DeleteCluster(ctx, clusterID, name.(string))
+	backupRetentionDays := d.Get("backup_retention_days").(int)
+
+	r, err := c.DeleteCluster(ctx, clusterID, name.(string), backupRetentionDays)
 	if err != nil {
 		if scylla.IsDeletedErr(err) {
 			return nil // cluster was already deleted

--- a/internal/provider/cluster/cluster_test.go
+++ b/internal/provider/cluster/cluster_test.go
@@ -427,3 +427,45 @@ func TestIsScalingEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateBackupRetentionDaysDiag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value int
+		valid bool
+	}{
+		{name: "negative", value: -1},
+		{name: "above max", value: 61},
+		{name: "way above max", value: 100},
+		{name: "zero", value: 0, valid: true},
+		{name: "one (default)", value: 1, valid: true},
+		{name: "max", value: 60, valid: true},
+		{name: "mid range", value: 30, valid: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := validateBackupRetentionDaysDiag(tt.value, cty.Path{})
+			if tt.valid {
+				require.Nil(t, diags)
+				return
+			}
+
+			require.NotNil(t, diags)
+		})
+	}
+}
+
+func TestBackupRetentionDaysSchemaDefault(t *testing.T) {
+	t.Parallel()
+
+	resource := ResourceCluster()
+	s, ok := resource.Schema["backup_retention_days"]
+	require.True(t, ok, "backup_retention_days schema field must exist")
+	require.Equal(t, 1, s.Default, "default must be 1 to prevent accidental data loss")
+	require.True(t, s.Optional, "field must be optional")
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -57,14 +57,15 @@ func TestAccScyllaDBCloudCluster_basicAWS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
-  name           = %[1]q
-  cloud          = "AWS"
-  region         = "us-east-1"
-  node_type      = "i3.large"
-  min_nodes      = 3
-  scylla_version = "2026.1.1"
-  cidr_block     = "10.0.1.0/24"
-  enable_dns     = true
+  name                  = %[1]q
+  cloud                 = "AWS"
+  region                = "us-east-1"
+  node_type             = "i3.large"
+  min_nodes             = 3
+  scylla_version        = "2026.1.1"
+  cidr_block            = "10.0.1.0/24"
+  enable_dns            = true
+  backup_retention_days = 0
   availability_zone_ids = ["use1-az2", "use1-az4", "use1-az6"]
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -124,11 +125,12 @@ func TestAccScyllaDBCloudCluster_xcloudAWS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
-  name       = %[1]q
-  cloud      = "AWS"
-  region     = "us-east-1"
-  cidr_block = "10.0.1.0/24"
-  enable_dns = true
+  name                  = %[1]q
+  cloud                 = "AWS"
+  region                = "us-east-1"
+  cidr_block            = "10.0.1.0/24"
+  enable_dns            = true
+  backup_retention_days = 0
   availability_zone_ids = ["use1-az2", "use1-az4", "use1-az6"]
   scaling {
     instance_families = ["i4i"]
@@ -191,13 +193,14 @@ func TestAccScyllaDBCloudCluster_basicAWSSingleAZ(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
-  name       = %[1]q
-  cloud      = "AWS"
-  region     = "us-east-1"
-  node_type  = "i3.large"
-  min_nodes  = 3
-  cidr_block = "10.0.1.0/24"
-  enable_dns = true
+  name                  = %[1]q
+  cloud                 = "AWS"
+  region                = "us-east-1"
+  node_type             = "i3.large"
+  min_nodes             = 3
+  cidr_block            = "10.0.1.0/24"
+  enable_dns            = true
+  backup_retention_days = 0
   availability_zone_ids = ["use1-az2"]
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -242,13 +245,14 @@ func TestAccScyllaDBCloudCluster_basicAWSScaleOut(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
-  name       = %[1]q
-  cloud      = "AWS"
-  region     = "us-east-1"
-  node_type  = "i3.large"
-  min_nodes  = 3
-  cidr_block = "10.0.1.0/24"
-  enable_dns = true
+  name                  = %[1]q
+  cloud                 = "AWS"
+  region                = "us-east-1"
+  node_type             = "i3.large"
+  min_nodes             = 3
+  cidr_block            = "10.0.1.0/24"
+  enable_dns            = true
+  backup_retention_days = 0
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					clusterIDCompare.AddStateValue(
@@ -272,13 +276,14 @@ func TestAccScyllaDBCloudCluster_basicAWSScaleOut(t *testing.T) {
 			},
 			{
 				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
-  name       = %[1]q
-  cloud      = "AWS"
-  region     = "us-east-1"
-  node_type  = "i3.large"
-  min_nodes  = 6
-  cidr_block = "10.0.1.0/24"
-  enable_dns = true
+  name                  = %[1]q
+  cloud                 = "AWS"
+  region                = "us-east-1"
+  node_type             = "i3.large"
+  min_nodes             = 6
+  cidr_block            = "10.0.1.0/24"
+  enable_dns            = true
+  backup_retention_days = 0
 }`, resourceName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -320,13 +325,14 @@ func TestAccScyllaDBCloudCluster_scaleOutFromOutside(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
-  name       = %[1]q
-  cloud      = "AWS"
-  region     = "us-east-1"
-  node_type  = "i3.large"
-  min_nodes  = 3
-  cidr_block = "10.0.1.0/24"
-  enable_dns = true
+  name                  = %[1]q
+  cloud                 = "AWS"
+  region                = "us-east-1"
+  node_type             = "i3.large"
+  min_nodes             = 3
+  cidr_block            = "10.0.1.0/24"
+  enable_dns            = true
+  backup_retention_days = 0
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -381,13 +387,14 @@ func TestAccScyllaDBCloudCluster_basicGCP(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
-  name       = %[1]q
-  cloud      = "GCP"
-  region     = "us-central1"
-  node_type  = "n2d-highmem-2"
-  min_nodes  = 3
-  cidr_block = "10.0.1.0/24"
-  enable_dns = true
+  name                  = %[1]q
+  cloud                 = "GCP"
+  region                = "us-central1"
+  node_type             = "n2d-highmem-2"
+  min_nodes             = 3
+  cidr_block            = "10.0.1.0/24"
+  enable_dns            = true
+  backup_retention_days = 0
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -427,14 +434,15 @@ func TestAccScyllaDBCloudCluster_basicGCPBYOA(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
-  name       = %[1]q
-  cloud      = "GCP"
-  region     = "us-central1"
-  node_type  = "n2d-highmem-2"
-  min_nodes  = 3
-  cidr_block = "10.0.1.0/24"
-  enable_dns = true
-  byoa_id    = %[2]s
+  name                  = %[1]q
+  cloud                 = "GCP"
+  region                = "us-central1"
+  node_type             = "n2d-highmem-2"
+  min_nodes             = 3
+  cidr_block            = "10.0.1.0/24"
+  enable_dns            = true
+  backup_retention_days = 0
+  byoa_id              = %[2]s
 }`, resourceName, byoaID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -446,6 +454,42 @@ func TestAccScyllaDBCloudCluster_basicGCPBYOA(t *testing.T) {
 						"scylladbcloud_cluster.test",
 						tfjsonpath.New("node_count"),
 						knownvalue.Int32Exact(3),
+					),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScyllaDBCloudClusterExists(ctx, "scylladbcloud_cluster.test", &cluster),
+				),
+			},
+		},
+	})
+}
+
+func TestAccScyllaDBCloudCluster_backupRetentionDefault(t *testing.T) {
+	ctx := t.Context()
+	resourceName := acctest.RandomWithPrefix("backup-retention-default")
+
+	var cluster model.Cluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: protoV5ProviderFactories,
+		CheckDestroy:             testAccCheckScyllaDBCloudClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
+  name       = %[1]q
+  cloud      = "AWS"
+  region     = "us-east-1"
+  node_type  = "i3.large"
+  min_nodes  = 3
+  cidr_block = "10.0.1.0/24"
+  enable_dns = true
+}`, resourceName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("backup_retention_days"),
+						knownvalue.Int32Exact(1),
 					),
 				},
 				Check: resource.ComposeTestCheckFunc(
@@ -509,13 +553,14 @@ func TestAccScyllaDBCloudCluster_migrationV1ToV2(t *testing.T) {
 			{
 				ProtoV5ProviderFactories: protoV5ProviderFactories,
 				Config: fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
-  name       = %[1]q
-  cloud      = "AWS"
-  region     = "us-east-1"
-  node_type  = "i3.large"
-  min_nodes  = 3
-  cidr_block = "10.0.1.0/24"
-  enable_dns = true
+  name                  = %[1]q
+  cloud                 = "AWS"
+  region                = "us-east-1"
+  node_type             = "i3.large"
+  min_nodes             = 3
+  cidr_block            = "10.0.1.0/24"
+  enable_dns            = true
+  backup_retention_days = 0
 }`, resourceName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/provider/serverless/serverless_cluster.go
+++ b/internal/provider/serverless/serverless_cluster.go
@@ -207,7 +207,7 @@ func resourceServerlessClusterDelete(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("unable to read serverless cluster name from state file")
 	}
 
-	r, err := c.DeleteCluster(ctx, clusterID, name.(string))
+	r, err := c.DeleteCluster(ctx, clusterID, name.(string), 0)
 	if err != nil {
 		return diag.Errorf("error deleting serverlessCluster: %s", err)
 	}

--- a/internal/scylla/endpoints.go
+++ b/internal/scylla/endpoints.go
@@ -135,12 +135,13 @@ func (c *Client) CreateCluster(ctx context.Context, req *model.ClusterCreateRequ
 	return &clusterReq, nil
 }
 
-func (c *Client) DeleteCluster(ctx context.Context, clusterID int64, clusterName string) (*model.ClusterRequest, error) {
+func (c *Client) DeleteCluster(ctx context.Context, clusterID int64, clusterName string, backupRetentionDays int) (*model.ClusterRequest, error) {
 	var result model.ClusterRequest
 
 	path := fmt.Sprintf("/account/%d/cluster/%d/delete", c.AccountID, clusterID)
 	data := map[string]interface{}{
-		"clusterName": clusterName,
+		"clusterName":         clusterName,
+		"backupRetentionDays": backupRetentionDays,
 	}
 
 	if err := c.post(ctx, path, data, &result); err != nil {

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -32,6 +32,10 @@ resource "scylladbcloud_cluster" "standard" {
   node_type  = "i3.large"
   min_nodes  = 3
   cidr_block = "10.0.1.0/24"
+
+  # Set to 0 to delete backups immediately after cluster deletion.
+  # Defaults to 1 to prevent accidental data loss.
+  backup_retention_days = 1
 }
 ```
 
@@ -43,6 +47,10 @@ resource "scylladbcloud_cluster" "xcloud" {
   cloud      = "AWS"
   region     = "us-east-1"
   cidr_block = "10.0.1.0/24"
+
+  # Set to 0 to delete backups immediately after cluster deletion.
+  # Defaults to 1 to prevent accidental data loss.
+  backup_retention_days = 1
 
   scaling {
     instance_families = ["i8g"]


### PR DESCRIPTION
This adds support for `backup_retention_days` parameter to cluster resource which specifies how many days to keep cluster backups alive after cluster deletion.

When cluster resource is destroyed, value of this parameter is passed to delete cluster API. Allowed range is [0, 60] - where 0 means that backups will be deleted immediately with the cluster. Default value for this parameter is set to 1 to prevent accidental data loss ( e.g. user haven't paid attention to the terraform plan with cluster replace change and applied it ).

Existing acceptance tests are modified with the explicit `backup_retention_days = 0` as we don't need to keep backups for 1 days for test clusters.

Fixes: CLOUD-2399


### How this has been tested

1. Executed `make testacc` (pointing to the lab account) - :green_circle: 
2. Manually, by checking what is in the backoffice for newly added `TestAccScyllaDBCloudCluster_backupRetentionDefault`:
<img width="2322" height="336" alt="image" src="https://github.com/user-attachments/assets/dbd4e57b-7694-47c4-96f8-77316767c9f7" />

3. Manually, following scenario: cluster is already managed in terraform and then provider is updated with current change, then terraform will produce following plan:
```
Terraform will perform the following actions:

  # scylladbcloud_cluster.example will be updated in-place
  ~ resource "scylladbcloud_cluster" "example" {
      + backup_retention_days      = 1
        id                         = "4961"
        name                       = "va-tf-test-bk-cluster"
        # (19 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
So it's up to a user whether to accept a new default or to explicitly set `backup_retention_days` to `0`