### PR TITLE
feat(cluster): encrypt new clusters by default

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,11 +5,16 @@ on:
     branches:
     - "main"
   pull_request:
-    branches:
-    - "main"
 
 permissions:
   contents: read
+
+# Supersede in-flight runs for a pull request. Rebasing a stack force-pushes
+# every branch in it, so each rebase would otherwise start a full matrix run
+# per pull request. Pushes to main are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,6 +108,20 @@ The provider supports specifying exact availability zone placement for cluster n
 
 ~> **Note:** You must provide at least two availability zone IDs when using this field.
 
+## Encryption at Rest
+
+New clusters are created with database-level encryption at rest enabled, using a ScyllaDB-managed key, matching what the ScyllaDB Cloud portal does. No configuration is required.
+
+To use a customer-managed key instead, create it in the ScyllaDB Cloud portal first and pass its ID:
+
+```terraform
+encryption_at_rest {
+  key_id = "key-deadbeef"
+}
+```
+
+~> **Note:** Encryption at rest can only be configured when a cluster is created, so changing any field in this block replaces the cluster. Clusters created before this default was introduced are unaffected: omitting the block keeps whatever the cluster already uses and never plans a replacement.
+
 ## Useful Links
 
 [Reporting bugs or feature requests](https://github.com/scylladb/terraform-provider-scylladbcloud/issues)

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -24,16 +24,14 @@ resource "scylladbcloud_cluster" "example" {
 	enable_vpc_peering = true
 	enable_dns         = true
 
-	# Encrypt the cluster data at rest with a ScyllaDB-managed key.
-	# Use `key_id` instead to point at a customer-managed key created
-	# beforehand in the ScyllaDB Cloud portal:
+	# Encryption at rest is enabled by default using a key managed by ScyllaDB Cloud.
+	# This block is optional and should only be configured if you wish to use a
+	# customer-managed key previously created in the ScyllaDB Cloud portal.
 	#
 	#   encryption_at_rest {
 	#     key_id = "key-deadbeef"
 	#   }
-	encryption_at_rest {
-		enabled = true
-	}
+	#
 }
 
 output "scylladbcloud_cluster_id" {
@@ -71,7 +69,7 @@ output "scylladbcloud_cluster_encryption_key_provider" {
 - `cloud` (String) The cloud provider. Accepted values: AWS, GCP.
 - `enable_dns` (Boolean) Whether to enable DNS for the cluster.
 - `enable_vpc_peering` (Boolean) Whether to enable VPC peering for the cluster.
-- `encryption_at_rest` (Block List, Max: 1) Enables database-level encryption at rest. The key provider is derived from the `cloud` attribute. Encryption at rest can only be configured when the cluster is created, so changing any field in this block replaces the cluster. Omitting the block leaves the cluster unencrypted. (see [below for nested schema](#nestedblock--encryption_at_rest))
+- `encryption_at_rest` (Block List, Max: 1) Configures database-level encryption at rest. The key provider is derived from the `cloud` attribute. Encryption at rest can only be configured when the cluster is created, so changing any field in this block replaces the cluster. New clusters are encrypted with a ScyllaDB-managed key by default. The block is needed to opt out with `enabled = false` or to point at a customer-managed key. Existing clusters are never modified. (see [below for nested schema](#nestedblock--encryption_at_rest))
 - `min_nodes` (Number) Minimum number of nodes in the cluster. Required for Standard clusters; must be at least 3 and divisible by 3. Must not be set when the scaling block is present, in which case it reads back as `0` and `node_count` reports the number of nodes the cluster currently runs. Increasing this value scales the cluster out; decreasing it scales the cluster in. Either operation takes effect immediately on `terraform apply` and does not force cluster re-creation.
 - `node_disk_size` (Number) The disk size in gigabytes of the node. Must not be set when the scaling block is present, in which case it reads back as `0`: the control plane picks the instance from the scaling policy and changes it as the cluster scales.
 - `node_type` (String) The instance type for cluster nodes (e.g. i8g.large). Required for Standard clusters. Must not be set when the scaling block is present, in which case it reads back as empty: the control plane picks the instance from the scaling policy and changes it as the cluster scales.
@@ -97,7 +95,7 @@ output "scylladbcloud_cluster_encryption_key_provider" {
 
 Optional:
 
-- `enabled` (Boolean) Whether the cluster data is encrypted at rest. Defaults to true when the block is present; set it to false to opt out explicitly.
+- `enabled` (Boolean) Whether the cluster data is encrypted at rest. Defaults to true; set it to false to create the cluster unencrypted.
 - `key_id` (String) The ID of a customer-managed key pre-created in the ScyllaDB Cloud portal (e.g. `key-deadbeef`). Leave it unset to let ScyllaDB Cloud manage the key.
 
 Read-Only:

--- a/examples/resources/scylladbcloud_cluster/resource.tf
+++ b/examples/resources/scylladbcloud_cluster/resource.tf
@@ -10,16 +10,14 @@ resource "scylladbcloud_cluster" "example" {
 	enable_vpc_peering = true
 	enable_dns         = true
 
-	# Encrypt the cluster data at rest with a ScyllaDB-managed key.
-	# Use `key_id` instead to point at a customer-managed key created
-	# beforehand in the ScyllaDB Cloud portal:
+	# Encryption at rest is enabled by default using a key managed by ScyllaDB Cloud.
+	# This block is optional and should only be configured if you wish to use a
+	# customer-managed key previously created in the ScyllaDB Cloud portal.
 	#
 	#   encryption_at_rest {
 	#     key_id = "key-deadbeef"
 	#   }
-	encryption_at_rest {
-		enabled = true
-	}
+	#
 }
 
 output "scylladbcloud_cluster_id" {

--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -194,18 +194,25 @@ func isCustomerManagedKeyProvider(provider string) bool {
 // encryption_at_rest block. The key provider is derived from cloud so that
 // users never have to restate AWS/GCP. A nil result means the field is left out
 // of the request entirely, which is how encryption at rest is opted out of.
+//
+// Omitting the block selects a ScyllaDB-managed key, matching the desired default.
+// Opting out takes an explicit "enabled = false".
 func expandEncryptionAtRest(cloud string, raw interface{}) (*model.EncryptionAtRest, error) {
-	block, ok := castToNestedBlock(raw)
-	if !ok {
-		return nil, nil
-	}
+	block, configured := castToNestedBlock(raw)
 
-	if enabled, _ := block["enabled"].(bool); !enabled {
-		return nil, nil
+	if configured {
+		if enabled, _ := block["enabled"].(bool); !enabled {
+			return nil, nil
+		}
 	}
 
 	providers, ok := encryptionKeyProviders[strings.ToLower(cloud)]
 	if !ok {
+		if !configured {
+			// The default must never fail a create for a cloud the user did
+			// not ask to encrypt on.
+			return nil, nil
+		}
 		return nil, fmt.Errorf("encryption at rest is not supported for cloud %q", cloud)
 	}
 
@@ -218,6 +225,55 @@ func expandEncryptionAtRest(cloud string, raw interface{}) (*model.EncryptionAtR
 	}
 
 	return &model.EncryptionAtRest{Provider: providers.scyllaManaged}, nil
+}
+
+// createClusterWithEncryptionFallback creates the cluster, retrying once
+// without encryption at rest when the account is not entitled to it and the
+// user never asked for it.
+//
+// Encryption at rest is on by default, so an account without the entitlement
+// would otherwise fail every "terraform apply" over a setting it did not
+// choose. The retry is deliberately narrow: only error 040723, which the API
+// rejects on the cluster POST before anything is provisioned. Retrying on any
+// other error risks creating a second cluster, because CreateCluster also
+// fetches the cluster request it just enqueued.
+//
+// An explicitly configured block always fails hard - a user who asked for
+// encryption must not silently get an unencrypted cluster.
+func createClusterWithEncryptionFallback(
+	ctx context.Context,
+	c *scylla.Client,
+	req *model.ClusterCreateRequest,
+	encryptionConfigured bool,
+) (*model.ClusterRequest, diag.Diagnostics, error) {
+	cr, err := c.CreateCluster(ctx, req)
+	if err == nil {
+		return cr, nil, nil
+	}
+
+	if encryptionConfigured || req.EncryptionAtRest == nil || !scylla.IsEncryptionAtRestUnavailableErr(err) {
+		return nil, nil, err
+	}
+
+	tflog.Debug(ctx, "Account is not entitled to encryption at rest; retrying without it", map[string]interface{}{
+		"cluster_name": req.ClusterName,
+	})
+
+	req.EncryptionAtRest = nil
+
+	cr, err = c.CreateCluster(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cr, diag.Diagnostics{{
+		Severity: diag.Warning,
+		Summary:  fmt.Sprintf("Cluster %q was created without encryption at rest", req.ClusterName),
+		Detail: "This account is not entitled to encryption at rest, which new clusters use by " +
+			"default. The cluster was created unencrypted. Contact ScyllaDB Cloud support to " +
+			`enable it, or set "enabled = false" in the "encryption_at_rest" block to silence ` +
+			"this warning.",
+	}}, nil
 }
 
 // flattenEncryptionAtRest always returns exactly one block, never an empty
@@ -710,10 +766,12 @@ func ResourceCluster() *schema.Resource {
 				ValidateDiagFunc: validateBackupRetentionDaysDiag,
 			},
 			"encryption_at_rest": {
-				Description: "Enables database-level encryption at rest. The key provider is derived from " +
+				Description: "Configures database-level encryption at rest. The key provider is derived from " +
 					"the `cloud` attribute. Encryption at rest can only be configured when the cluster is " +
 					"created, so changing any field in this block replaces the cluster. " +
-					"Omitting the block leaves the cluster unencrypted.",
+					"New clusters are encrypted with a ScyllaDB-managed key by default. The block is " +
+					"needed to opt out with `enabled = false` or to point at a customer-managed key. " +
+					"Existing clusters are never modified.",
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
@@ -721,8 +779,8 @@ func ResourceCluster() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
 					"enabled": {
-						Description: "Whether the cluster data is encrypted at rest. Defaults to true when the " +
-							"block is present; set it to false to opt out explicitly.",
+						Description: "Whether the cluster data is encrypted at rest. Defaults to true; set it " +
+							"to false to create the cluster unencrypted.",
 						Optional: true,
 						ForceNew: true,
 						Default:  true,
@@ -893,7 +951,9 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf(`unrecognized value %q for "scylla_version" attribute`, version)
 	}
 
-	cr, err := scyllaClient.CreateCluster(ctx, clusterCreateRequest)
+	_, encryptionConfigured := configuredEncryptionAtRest(d.GetRawConfig())
+
+	cr, warns, err := createClusterWithEncryptionFallback(ctx, scyllaClient, clusterCreateRequest, encryptionConfigured)
 	if err != nil {
 		return diag.Errorf("failed to create a cluster request: %s", err)
 	}
@@ -923,7 +983,9 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 		instanceExternalID = i.ExternalID
 	}
-	caCert, warns := fetchCACertificate(ctx, scyllaClient, cluster.ID, "")
+	caCert, certWarns := fetchCACertificate(ctx, scyllaClient, cluster.ID, "")
+	warns = append(warns, certWarns...)
+
 	err = setClusterKVs(d, cluster, cloudProvider.CloudProvider.Name, instanceExternalID, caCert, instances, cloudProvider)
 	if err != nil {
 		return diag.Errorf("failed to set cluster values for cluster %d: %s", cluster.ID, err)

--- a/internal/provider/cluster/cluster_test.go
+++ b/internal/provider/cluster/cluster_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -607,6 +608,114 @@ func TestFetchCACertificate(t *testing.T) {
 	}
 }
 
+func TestCreateClusterWithEncryptionFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// createError is the body the cluster POST answers with while it still
+		// carries encryptionAtRest. Empty means the first attempt succeeds.
+		createError string
+		configured  bool
+		wantPosts   []*model.EncryptionAtRest
+		wantDiags   int
+		wantErr     string
+	}{
+		{
+			name:      "creates encrypted when the account is entitled",
+			wantPosts: []*model.EncryptionAtRest{{Provider: "scylla-aws"}},
+		},
+		{
+			name:        "retries unencrypted when the account is not entitled",
+			createError: "040723",
+			wantPosts:   []*model.EncryptionAtRest{{Provider: "scylla-aws"}, nil},
+			wantDiags:   1,
+		},
+		{
+			name:        "fails when the user asked for encryption explicitly",
+			createError: "040723",
+			configured:  true,
+			wantPosts:   []*model.EncryptionAtRest{{Provider: "scylla-aws"}},
+			wantErr:     "040723",
+		},
+		{
+			name:        "never retries an invalid encryption parameter",
+			createError: "040733",
+			wantPosts:   []*model.EncryptionAtRest{{Provider: "scylla-aws"}},
+			wantErr:     "040733",
+		},
+		{
+			name:        "never retries an unrelated failure",
+			createError: "040001",
+			wantPosts:   []*model.EncryptionAtRest{{Provider: "scylla-aws"}},
+			wantErr:     "040001",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var posts []*model.EncryptionAtRest
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/account/7/cluster":
+					var body model.ClusterCreateRequest
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+					posts = append(posts, body.EncryptionAtRest)
+
+					if tt.createError != "" && body.EncryptionAtRest != nil {
+						w.WriteHeader(http.StatusBadRequest)
+						_, _ = w.Write([]byte(`{"error":"` + tt.createError + `"}`))
+						return
+					}
+					_, _ = w.Write([]byte(`{"data":{"requestId":11}}`))
+				case "/account/7/cluster/request/11":
+					_, _ = w.Write([]byte(`{"data":{"id":11,"clusterId":42}}`))
+				default:
+					t.Errorf("unexpected path %q", r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+
+			endpoint, err := url.Parse(srv.URL)
+			require.NoError(t, err)
+
+			client := &scylla.Client{
+				Endpoint:   endpoint,
+				Headers:    make(http.Header),
+				HTTPClient: srv.Client(),
+				Retry:      retrier.New(nil, nil),
+				AccountID:  7,
+			}
+
+			req := &model.ClusterCreateRequest{
+				ClusterName:      "encrypted-by-default",
+				EncryptionAtRest: &model.EncryptionAtRest{Provider: model.EncryptionProviderScyllaAWS},
+			}
+
+			cr, diags, err := createClusterWithEncryptionFallback(context.Background(), client, req, tt.configured)
+			require.Equal(t, tt.wantPosts, posts)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Nil(t, cr)
+				require.Empty(t, diags)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, int64(42), cr.ClusterID)
+			require.Len(t, diags, tt.wantDiags)
+			if tt.wantDiags > 0 {
+				require.Equal(t, diag.Warning, diags[0].Severity)
+				require.Contains(t, diags[0].Detail, "not entitled to encryption at rest")
+			}
+		})
+	}
+}
+
 func TestSetClusterKVsSetsCACertificate(t *testing.T) {
 	t.Parallel()
 
@@ -645,8 +754,22 @@ func TestExpandEncryptionAtRest(t *testing.T) {
 		want  *model.EncryptionAtRest
 	}{
 		{
-			name:  "returns nil for absent block",
+			name:  "defaults to a scylla managed key for aws when the block is absent",
 			cloud: "AWS",
+			raw:   []interface{}{},
+			want:  &model.EncryptionAtRest{Provider: "scylla-aws"},
+		},
+		{
+			name:  "defaults to a scylla managed key for gcp when the block is absent",
+			cloud: "GCP",
+			raw:   []interface{}{},
+			want:  &model.EncryptionAtRest{Provider: "scylla-gcp"},
+		},
+		{
+			// The user did not ask for encryption, so an unsupported cloud must
+			// not start failing creates.
+			name:  "returns nil for an absent block on an unsupported cloud",
+			cloud: "AZURE",
 			raw:   []interface{}{},
 			want:  nil,
 		},

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -71,6 +71,10 @@ func TestAccScyllaDBCloudCluster_basicAWS(t *testing.T) {
   enable_dns            = true
   backup_retention_days = 0
   availability_zone_ids = ["use1-az2", "use1-az4", "use1-az6"]
+
+  encryption_at_rest {
+    enabled = false
+  }
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -151,6 +155,10 @@ func TestAccScyllaDBCloudCluster_xcloudAWS(t *testing.T) {
       min = 8
     }
   }
+
+  encryption_at_rest {
+    enabled = false
+  }
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -211,6 +219,10 @@ func TestAccScyllaDBCloudCluster_basicAWSSingleAZ(t *testing.T) {
   enable_dns            = true
   backup_retention_days = 0
   availability_zone_ids = ["use1-az2"]
+
+  encryption_at_rest {
+    enabled = false
+  }
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -262,6 +274,10 @@ func TestAccScyllaDBCloudCluster_basicAWSScaleOut(t *testing.T) {
   cidr_block            = "10.0.1.0/24"
   enable_dns            = true
   backup_retention_days = 0
+
+  encryption_at_rest {
+    enabled = false
+  }
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					clusterIDCompare.AddStateValue(
@@ -293,6 +309,10 @@ func TestAccScyllaDBCloudCluster_basicAWSScaleOut(t *testing.T) {
   cidr_block            = "10.0.1.0/24"
   enable_dns            = true
   backup_retention_days = 0
+
+  encryption_at_rest {
+    enabled = false
+  }
 }`, resourceName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -342,6 +362,10 @@ func TestAccScyllaDBCloudCluster_scaleOutFromOutside(t *testing.T) {
   cidr_block            = "10.0.1.0/24"
   enable_dns            = true
   backup_retention_days = 0
+
+  encryption_at_rest {
+    enabled = false
+  }
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -404,6 +428,10 @@ func TestAccScyllaDBCloudCluster_basicGCP(t *testing.T) {
   cidr_block            = "10.0.1.0/24"
   enable_dns            = true
   backup_retention_days = 0
+
+  encryption_at_rest {
+    enabled = false
+  }
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -452,6 +480,10 @@ func TestAccScyllaDBCloudCluster_basicGCPBYOA(t *testing.T) {
   enable_dns            = true
   backup_retention_days = 0
   byoa_id              = %[2]s
+
+  encryption_at_rest {
+    enabled = false
+  }
 }`, resourceName, byoaID),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -493,6 +525,10 @@ func TestAccScyllaDBCloudCluster_backupRetentionDefault(t *testing.T) {
   min_nodes  = 3
   cidr_block = "10.0.1.0/24"
   enable_dns = true
+
+  encryption_at_rest {
+    enabled = false
+  }
 }`, resourceName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -540,6 +576,19 @@ func testAccEncryptionAtRestEnabledConfig(name, cloud, region, nodeType string, 
 func testAccEncryptionAtRestKeyConfig(name, cloud, region, nodeType, keyID string) string {
 	return testAccEncryptionAtRestConfig(name, cloud, region, nodeType,
 		fmt.Sprintf("key_id = %q", keyID))
+}
+
+func testAccEncryptionAtRestDefaultConfig(name, cloud, region, nodeType string) string {
+	return fmt.Sprintf(`resource "scylladbcloud_cluster" "test" {
+  name                  = %[1]q
+  cloud                 = %[2]q
+  region                = %[3]q
+  node_type             = %[4]q
+  min_nodes             = 3
+  cidr_block            = "10.0.1.0/24"
+  enable_dns            = true
+  backup_retention_days = 0
+}`, name, cloud, region, nodeType)
 }
 
 func TestAccScyllaDBCloudCluster_encryptionAtRestEnabled(t *testing.T) {
@@ -710,6 +759,154 @@ func TestAccScyllaDBCloudCluster_encryptionAtRestCMK(t *testing.T) {
 	})
 }
 
+func TestAccScyllaDBCloudCluster_encryptionAtRestDefault(t *testing.T) {
+	ctx := t.Context()
+	resourceName := acctest.RandomWithPrefix("ear-default")
+
+	var cluster model.Cluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: protoV5ProviderFactories,
+		CheckDestroy:             testAccCheckScyllaDBCloudClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEncryptionAtRestDefaultConfig(resourceName, "AWS", "us-east-1", "i3.large"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("encryption_at_rest").AtSliceIndex(0).AtMapKey("enabled"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("encryption_at_rest").AtSliceIndex(0).AtMapKey("provider"),
+						knownvalue.StringExact("scylla-aws"),
+					),
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("encryption_at_rest").AtSliceIndex(0).AtMapKey("key_id"),
+						knownvalue.StringRegexp(regexp.MustCompile(`^key-`)),
+					),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScyllaDBCloudClusterExists(ctx, "scylladbcloud_cluster.test", &cluster),
+				),
+			},
+			{
+				// The block is Computed, so leaving it out of the configuration
+				// must keep planning a no-op rather than a replacement.
+				Config:   testAccEncryptionAtRestDefaultConfig(resourceName, "AWS", "us-east-1", "i3.large"),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccScyllaDBCloudCluster_encryptionAtRestDefaultGCP(t *testing.T) {
+	ctx := t.Context()
+	resourceName := acctest.RandomWithPrefix("ear-default-gcp")
+
+	var cluster model.Cluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: protoV5ProviderFactories,
+		CheckDestroy:             testAccCheckScyllaDBCloudClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEncryptionAtRestDefaultConfig(resourceName, "GCP", "us-central1", "n2d-highmem-2"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("encryption_at_rest").AtSliceIndex(0).AtMapKey("enabled"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("encryption_at_rest").AtSliceIndex(0).AtMapKey("provider"),
+						knownvalue.StringExact("scylla-gcp"),
+					),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScyllaDBCloudClusterExists(ctx, "scylladbcloud_cluster.test", &cluster),
+				),
+			},
+		},
+	})
+}
+
+// TestAccScyllaDBCloudCluster_encryptionAtRestNoDiffOnUpgrade verifies that
+// making encryption-at-rest default is backward compatible.
+//
+// encryption_at_rest is ForceNew, so if an absent block ever diffed against an
+// existing cluster, upgrading the provider would destroy and recreate every
+// cluster under management. 1.12 has no encryption_at_rest attribute at all,
+// which makes it the real upgrade path: state written before the attribute
+// existed, read by a provider that now defaults it on.
+//
+// Note: comment out any dev_overrides for scylladb/scylladbcloud in
+// ~/.terraformrc before running this. An override wins over the version pin
+// below and would silently test the local build against itself.
+func TestAccScyllaDBCloudCluster_encryptionAtRestNoDiffOnUpgrade(t *testing.T) {
+	ctx := t.Context()
+	resourceName := acctest.RandomWithPrefix("ear-no-diff-on-upgrade")
+
+	var cluster model.Cluster
+
+	clusterIDCompare := statecheck.CompareValue(compare.ValuesSame())
+
+	config := testAccEncryptionAtRestDefaultConfig(resourceName, "AWS", "us-east-1", "i3.large")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckScyllaDBCloudClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"scylladbcloud": {
+						// The last version released without encryption at rest.
+						VersionConstraint: "1.12",
+						Source:            "scylladb/scylladbcloud",
+					},
+				},
+				Config: config,
+				ConfigStateChecks: []statecheck.StateCheck{
+					clusterIDCompare.AddStateValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("id"),
+					),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScyllaDBCloudClusterExists(ctx, "scylladbcloud_cluster.test", &cluster),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: protoV5ProviderFactories,
+				Config:                   config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Same cluster, not a replacement.
+					clusterIDCompare.AddStateValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("id"),
+					),
+					// The cluster predates the default and stays unencrypted.
+					statecheck.ExpectKnownValue(
+						"scylladbcloud_cluster.test",
+						tfjsonpath.New("encryption_at_rest").AtSliceIndex(0).AtMapKey("enabled"),
+						knownvalue.Bool(false),
+					),
+				},
+			},
+		},
+	})
+}
+
 func TestAccScyllaDBCloudCluster_migrationV1ToV2(t *testing.T) {
 	ctx := t.Context()
 	resourceName := acctest.RandomWithPrefix("basic-aws-migration-v1-to-v2")
@@ -771,6 +968,10 @@ func TestAccScyllaDBCloudCluster_migrationV1ToV2(t *testing.T) {
   cidr_block            = "10.0.1.0/24"
   enable_dns            = true
   backup_retention_days = 0
+
+  encryption_at_rest {
+    enabled = false
+  }
 }`, resourceName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/scylla/errors.go
+++ b/internal/scylla/errors.go
@@ -37,6 +37,16 @@ func IsEncryptionDisabledErr(err error) bool {
 	return false
 }
 
+// IsEncryptionAtRestUnavailableErr reports whether err is API error 040723:
+// "Account does not have encryption at rest enabled". It means the account is
+// not entitled to encryption at rest, not that the request was malformed.
+func IsEncryptionAtRestUnavailableErr(err error) bool {
+	if e := new(APIError); errors.As(err, &e) && e.Code == "040723" {
+		return true
+	}
+	return false
+}
+
 func IsNotFound(err error) bool {
 	if e := new(APIError); errors.As(err, &e) && e.StatusCode == http.StatusNotFound {
 		return true

--- a/internal/scylla/errors_test.go
+++ b/internal/scylla/errors_test.go
@@ -30,3 +30,26 @@ func TestIsEncryptionDisabledErr(t *testing.T) {
 		})
 	}
 }
+
+func TestIsEncryptionAtRestUnavailableErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error"},
+		{name: "plain error", err: errors.New("boom")},
+		{name: "invalid encryption parameter", err: &APIError{Code: "040733"}},
+		{name: "encryption at rest unavailable", err: &APIError{Code: "040723"}, want: true},
+		{name: "wrapped encryption at rest unavailable", err: fmt.Errorf("create cluster: %w", &APIError{Code: "040723"}), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, IsEncryptionAtRestUnavailableErr(tt.err))
+		})
+	}
+}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -87,6 +87,20 @@ The provider supports specifying exact availability zone placement for cluster n
 
 ~> **Note:** You must provide at least two availability zone IDs when using this field.
 
+## Encryption at Rest
+
+New clusters are created with database-level encryption at rest enabled, using a ScyllaDB-managed key, matching what the ScyllaDB Cloud portal does. No configuration is required.
+
+To use a customer-managed key instead, create it in the ScyllaDB Cloud portal first and pass its ID:
+
+```terraform
+encryption_at_rest {
+  key_id = "key-deadbeef"
+}
+```
+
+~> **Note:** Encryption at rest can only be configured when a cluster is created, so changing any field in this block replaces the cluster. Clusters created before this default was introduced are unaffected: omitting the block keeps whatever the cluster already uses and never plans a replacement.
+
 ## Useful Links
 
 [Reporting bugs or feature requests](https://github.com/scylladb/terraform-provider-scylladbcloud/issues)


### PR DESCRIPTION
Clusters created through Terraform came out unencrypted unless an encryption_at_rest block was given, while the portal enables database-level encryption by default.

Omitting the block now selects a ScyllaDB-managed key for the target cloud. Opting out takes an explicit "enabled = false".

Existing clusters are left alone. The block is Optional+Computed, so an absent block plans as whatever the cluster already uses rather than as a diff. That matters because the block is ForceNew: a diff here would replace every cluster under management on upgrade.

Fixes: CLOUD-3318