### PR TITLE
chore(xcloud): deprecate tablets field from xcloud cluster creation

### DIFF
--- a/internal/provider/cluster/cluster.go
+++ b/internal/provider/cluster/cluster.go
@@ -879,7 +879,6 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	if scaling != nil {
 		clusterCreateRequest.Scaling = scaling
-		clusterCreateRequest.Tablets = model.TabletsEnforced
 	} else {
 		minNodes := d.Get("min_nodes").(int)
 		clusterCreateRequest.NumberOfNodes = int64(minNodes)

--- a/internal/scylla/model/model.go
+++ b/internal/scylla/model/model.go
@@ -7,12 +7,6 @@ import (
 	"time"
 )
 
-type tabletsMode string
-
-const (
-	TabletsEnforced tabletsMode = "enforced"
-)
-
 type CloudProvider struct {
 	ID            int64  `json:"id"`
 	Name          string `json:"name"`
@@ -144,7 +138,6 @@ type ClusterCreateRequest struct {
 	InstanceID               int64             `json:"instanceId,omitempty"`
 	RegionID                 int64             `json:"regionId,omitempty"`
 	Scaling                  *Scaling          `json:"scaling,omitempty"`
-	Tablets                  tabletsMode       `json:"tablets,omitempty"`
 	EnableDNSAssociation     bool              `json:"enableDnsAssociation"`
 	AllowedIPs               []string          `json:"allowedIPs,omitempty"`
 	FreeTier                 bool              `json:"freeTier"`


### PR DESCRIPTION
We've deprecated tablets field from cluster creation on our public API this change removes from our terraform provider

related: https://github.com/scylladb/siren/pull/16098
closes: CLOUD-3492

Tested by provisioning xcloud cluster
```terraform
terraform {
  required_providers {
    scylladbcloud = {
      source = "registry.terraform.io/scylladb/scylladbcloud"
    }
  }
}


resource "scylladbcloud_cluster" "Bart_Simpson_1" {
  name       = "Bart_Simpson_2"
  cloud      = "AWS"
  region     = "us-east-1"
  cidr_block = "172.31.0.0/16"
  enable_vpc_peering = true
  enable_dns         = true
  scaling {
    instance_families = ["i4i"]

    storage_policy {
      min_gb                = 500
      target_utilization = 0.75
    }

    vcpu_policy {
      min = 8
    }
  }
}

output "min_nodes" {
  value = scylladbcloud_cluster.Bart_Simpson_1.min_nodes
}

```